### PR TITLE
Modifications to support quantity limits feature

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
 		[
 			"@babel/preset-env",
 			{
-			targets: { node: "current" },
+				targets: { node: "current" },
 				useBuiltIns: false
 			}
 		]

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -53,7 +53,7 @@ export class Entity {
 				this.init(properties, context);
 
 			// Raise the initNew or initExisting event on this type and all base types
-			context.ready().then(() => {
+			context.ready(() => {
 				for (let t = type; t; t = t.baseType) {
 					if (isNew)
 						(t.initNew as Event<Type, EntityInitExistingEventArgs>).publish(t, { entity: this });
@@ -62,12 +62,9 @@ export class Entity {
 				}
 
 				// Set values of new entity for provided properties
-				if (context.isAsync && isNew && properties)
+				if (isNew && properties)
 					this.set(properties);
 			});
-
-			if (!context.isAsync && isNew && properties)
-				this.set(properties);
 		}
 	}
 
@@ -191,11 +188,11 @@ export class Entity {
 		return this.meta.type.getProperty(property).value(this);
 	}
 
-	toString(format?: string, formatEval?: (tokenValue: string) => string): string {
+	toString(format?: string): string {
 		// Get the entity format to use
 		let formatter: Format<Entity> = null;
 		if (format) {
-			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format, formatEval);
+			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format);
 		}
 		else {
 			formatter = this.meta.type.format;
@@ -275,5 +272,5 @@ export interface EntityChangeEventArgs {
 	entity: Entity;
 	property: Property;
 	oldValue?: any;
-	newValue?: any;
+	newValue: any;
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -188,11 +188,11 @@ export class Entity {
 		return this.meta.type.getProperty(property).value(this);
 	}
 
-	toString(format?: string): string {
+	toString(format?: string, formatEval?: (tokenValue: string) => string): string {
 		// Get the entity format to use
 		let formatter: Format<Entity> = null;
 		if (format) {
-			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format);
+			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format, formatEval);
 		}
 		else {
 			formatter = this.meta.type.format;

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -27,13 +27,11 @@ export class InitializationContext {
 		return !this.constructorCall;
 	}
 
-	ready() {
+	ready(callback: () => void) {
 		if (this.tasks.size === 0)
-			return Promise.resolve();
+			callback();
 
-		return new Promise<void>(resolve => {
-			this.waiting.push(resolve);
-		});
+		this.waiting.push(callback);
 	}
 
 	tryResolveValue(instance: Entity, property: Property, value: any) {

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -23,10 +23,6 @@ export class InitializationContext {
 		});
 	}
 
-	get isAsync() {
-		return !this.constructorCall;
-	}
-
 	ready(callback: () => void) {
 		if (this.tasks.size === 0)
 			callback();

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -238,7 +238,7 @@ export class Rule {
 							// Defer change notification until the scope of work has completed
 							EventScope$onExit(() => {
 								rule.returnValues.forEach((returnValue) => {
-									(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue });
+									(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
 								});
 							});
 						}

--- a/src/type.ts
+++ b/src/type.ts
@@ -82,7 +82,7 @@ export class Type {
 		const Ctor = this.jstype as any;
 		const instance = new Ctor(state.Id, state, context) as Entity;
 
-		return context.ready().then(() => instance);
+		return new Promise(resolve => context.ready(() => resolve(instance)));
 	}
 
 	/** Generates a unique id suitable for an instance in the current type hierarchy. */

--- a/src/validation-rule.ts
+++ b/src/validation-rule.ts
@@ -12,15 +12,14 @@ export class ValidationRule extends ConditionRule implements PropertyRule {
 		options.name = options.name || "ValidatedProperty";
 
 		// store the property being validated
-		var property = options.property;
+		const property = options.property;
 
 		// ensure the properties and predicates to include the target property
-		if (!options.properties) {
-			options.properties = [property];
-		}
-		else if (options.properties.indexOf(property) < 0) {
+		if (!options.properties)
+			options.properties = [];
+
+		if (!options.properties.includes(property))
 			options.properties.push(property);
-		}
 
 		if (!options.onChangeOf) {
 			options.onChangeOf = [property];


### PR DESCRIPTION
1. Fix bug where synchronous entity initialization called `set()` asynchronously
2. Fix bug where constant values for properties could be initialized before type dependencies
3. Fix bug where `newValue` was not included in `EntityChangedEventArgs` when rule predicates change in certain cases
4. Add support for serializing a specific property of an entity, optionally forcing an output even if a converter ignores the property.
5. Add support for specifying a custom condition type code for property errors
6. Add support for specifying additional predicates to a `ValidationRule`
7. Add support for additional `ValidationRule` predicates in a property error definition
8. Add support for specifying a resource to use as property error message