### PR TITLE
Add `labelIsFormat` and `helptextIsFormat` getters for properties

### DIFF
--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -280,8 +280,16 @@ export class PropertyChain implements PropertyPath {
 		return this.lastProperty.label;
 	}
 
+	get labelIsFormat(): boolean {
+		return Format.hasTokens(this.label);
+	}
+
 	get helptext(): string {
 		return this.lastProperty.helptext;
+	}
+
+	get helptextIsFormat(): boolean {
+		return Format.hasTokens(this.helptext);
 	}
 
 	get name(): string {

--- a/src/property-path.ts
+++ b/src/property-path.ts
@@ -16,7 +16,9 @@ export interface PropertyPath {
 	readonly lastProperty: Property;
 
 	label: string;
+	readonly labelIsFormat: boolean;
 	helptext: string;
+	readonly helptextIsFormat: boolean;
 	isCalculated: boolean;
     format: Format<any>;
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -67,6 +67,14 @@ export class Property implements PropertyPath {
 		return this.constant !== null && this.constant !== undefined;
 	}
 
+	get labelIsFormat(): boolean {
+		return Format.hasTokens(this.label);
+	}
+
+	get helptextIsFormat(): boolean {
+		return Format.hasTokens(this.helptext);
+	}
+
 	get path(): string {
 		return this.name;
 	}

--- a/src/validation-rule.ts
+++ b/src/validation-rule.ts
@@ -36,7 +36,7 @@ export class ValidationRule extends ConditionRule implements PropertyRule {
 		// replace the property label token in the validation message if present
 		if (options.message && (typeof options.message === "function" || (typeof options.message === "string" && options.message.indexOf("{property}") >= 0))) {
 			// Property label with dynamic format tokens
-			if (Format.hasTokens(property.label)) {
+			if (property.labelIsFormat) {
 				// convert the property label into a model format
 				let format = rootType.model.getFormat(rootType.jstype, property.label);
 


### PR DESCRIPTION
Removes the need for external (ex: app, VueModel) direct access to format class to detect format tokens, so you can instead just work with the property directly