### PR TITLE
implement support for resource names as StringFormatRule message

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -4,7 +4,7 @@ import { EntityRegisteredEventArgs, Entity } from "./entity";
 import { Type, PropertyType, isEntityType, ValueType, TypeOptions, TypeExtensionOptions } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
-import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource } from "./resource";
+import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource, resourceExists } from "./resource";
 import { CultureInfo, formatNumber, parseNumber, formatDate, parseDate, expandDateFormat, getNumberStyle } from "./globalization";
 
 const valueTypes: { [name: string]: ValueType } = { string: String, number: Number, date: Date, boolean: Boolean };
@@ -98,6 +98,10 @@ export class Model {
 		if (params)
 			return replaceTokens(resource, params);
 		return resource;
+	}
+
+	resourceExists(name: string) {
+		return resourceExists(name, this.$resources, this.$locale);
 	}
 
 	/**

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -14,7 +14,11 @@ export type LocalizedResourcesMap = ObjectLookup<LocalizedResources>;
 /**
  * The dictionary of localized resource messages
  */
-export const Resources: LocalizedResourcesMap = { };
+export const Resources: LocalizedResourcesMap = {};
+
+function mapContainsResource(resources: LocalizedResourcesMap, locale: string, name: string) {
+	return hasOwnProperty(resources, locale) && hasOwnProperty(resources[locale], name);
+}
 
 /**
  * The default locale, can be changed via `setDefaultLocale(locale)`.
@@ -32,7 +36,7 @@ export function setDefaultLocale(locale: string): void {
 /**
  * Globally defined resources
  */
-const globalResources: LocalizedResourcesMap = { };
+const globalResources: LocalizedResourcesMap = {};
 
 /**
  * Globally define localized resource messages for the given locale
@@ -74,12 +78,19 @@ export function getResource(name: string, arg2?: LocalizedResourcesMap | string,
 
 	let res: string;
 
-	if (customResources && hasOwnProperty(customResources, locale) && hasOwnProperty(customResources[locale], name))
+	if (customResources && mapContainsResource(customResources, locale, name))
 		res = customResources[locale][name];
-	else if (hasOwnProperty(globalResources, locale) && hasOwnProperty(globalResources[locale], name))
+	else if (mapContainsResource(globalResources, locale, name))
 		res = globalResources[locale][name];
 	else
 		throw new Error("Resource '" + name + "' is not defined for locale '" + locale + "'.");
 
 	return res;
+}
+
+export function resourceExists(name: string, customResources?: LocalizedResourcesMap, locale?: string) {
+	if (!locale)
+		locale = defaultLocale || "en";
+
+	return mapContainsResource(globalResources, locale, name) || (customResources && mapContainsResource(customResources, locale, name));
 }

--- a/src/string-format-rule.ts
+++ b/src/string-format-rule.ts
@@ -18,14 +18,8 @@ export class StringFormatRule extends ValidationRule {
 			options.name = options.name || "StringFormat";
 
 			// see if the error message is a valid resource: {resource-name}
-			if (typeof options.message === "string" && /^{[^{}]+}$/.test(options.message)) {
-				const resource = options.message.substring(1, options.message.length - 1);
-				if (rootType.model.getResource(resource)) {
-					options.message = rootType.model.getResource(resource);
-				}
-				else {
-					delete options.message;
-				}
+			if (typeof options.message === "string" && rootType.model.resourceExists(options.message)) {
+				options.message = rootType.model.getResource(options.message);
 			}
 
 			// get the default validation message if not specified

--- a/src/string-format-rule.ts
+++ b/src/string-format-rule.ts
@@ -18,7 +18,7 @@ export class StringFormatRule extends ValidationRule {
 			options.name = options.name || "StringFormat";
 
 			// see if the error message is a valid resource: {resource-name}
-			if (typeof options.message === "string" && /^{([^{}]+)}$/.test(options.message)) {
+			if (typeof options.message === "string" && /^{[^{}]+}$/.test(options.message)) {
 				const resource = options.message.substring(1, options.message.length - 1);
 				if (rootType.model.getResource(resource)) {
 					options.message = rootType.model.getResource(resource);

--- a/src/string-format-rule.ts
+++ b/src/string-format-rule.ts
@@ -17,14 +17,9 @@ export class StringFormatRule extends ValidationRule {
 			// ensure the rule name is specified
 			options.name = options.name || "StringFormat";
 
-			// ensure the error message is a valid resource
-			if (typeof options.message === "string" && /^{[^{}]+}$/.test(options.message)) {
-				if (rootType.model.getResource(options.message)) {
-					options.message = rootType.model.getResource(options.message);
-				}
-				else {
-					delete options.message;
-				}
+			// see if error message is a valid resource
+			if (typeof options.message === "string" && rootType.model.getResource(options.message)) {
+				options.message = rootType.model.getResource(options.message);
 			}
 
 			// get the default validation message if not specified

--- a/src/string-format-rule.ts
+++ b/src/string-format-rule.ts
@@ -17,9 +17,15 @@ export class StringFormatRule extends ValidationRule {
 			// ensure the rule name is specified
 			options.name = options.name || "StringFormat";
 
-			// see if error message is a valid resource
-			if (typeof options.message === "string" && rootType.model.getResource(options.message)) {
-				options.message = rootType.model.getResource(options.message);
+			// see if the error message is a valid resource: {resource-name}
+			if (typeof options.message === "string" && /^{([^{}]+)}$/.test(options.message)) {
+				const resource = options.message.substring(1, options.message.length - 1);
+				if (rootType.model.getResource(resource)) {
+					options.message = rootType.model.getResource(resource);
+				}
+				else {
+					delete options.message;
+				}
 			}
 
 			// get the default validation message if not specified


### PR DESCRIPTION
A resource string can be used as the error message for StringFormatRules as follows:

```
format: {
        reformat: "$&",
        expression: /^([A-Za-z]+)$/,
        message: "string-format-alphabetic"
}
```