### PR TITLE
Standardize Date Time

### DIFF
--- a/src/condition-rule.ts
+++ b/src/condition-rule.ts
@@ -18,6 +18,8 @@ export class ConditionRule extends Rule {
 	// The condition type to raise when asserted
 	conditionType: ConditionType;
 
+	preExecute?: (this: ConditionRule, entity: Entity) => void;
+
 	/**
 	 * Creates a rule that asserts a condition based on a predicate
 	 * @param rootType The model type the rule is for
@@ -32,6 +34,9 @@ export class ConditionRule extends Rule {
 	
 		// assertion function
 		this.assert = options.assert;
+
+		// pre-execute
+		this.preExecute = options.preExecute;
 
 		// message
 		this.message = options.message;
@@ -50,6 +55,10 @@ export class ConditionRule extends Rule {
 	execute(entity: Entity): void {
 		let assert: boolean;
 		let message: string;
+
+		if(this.preExecute) {
+			this.preExecute(entity);
+		}
 
 		if (this.assert) {
 			// If an assert function is defined, then use it to determine whether to attach a condition
@@ -95,4 +104,5 @@ export interface ConditionRuleOptions extends RuleOptions {
 	// the optional array of condition type sets to associate the condition with
 	sets?: ConditionTypeSet[];
 
+	preExecute?: (this: ConditionRule, entity: Entity) => void;
 }

--- a/src/condition-rule.ts
+++ b/src/condition-rule.ts
@@ -18,8 +18,6 @@ export class ConditionRule extends Rule {
 	// The condition type to raise when asserted
 	conditionType: ConditionType;
 
-	preExecute?: (this: ConditionRule, entity: Entity) => void;
-
 	/**
 	 * Creates a rule that asserts a condition based on a predicate
 	 * @param rootType The model type the rule is for
@@ -34,9 +32,6 @@ export class ConditionRule extends Rule {
 	
 		// assertion function
 		this.assert = options.assert;
-
-		// pre-execute
-		this.preExecute = options.preExecute;
 
 		// message
 		this.message = options.message;
@@ -55,10 +50,6 @@ export class ConditionRule extends Rule {
 	execute(entity: Entity): void {
 		let assert: boolean;
 		let message: string;
-
-		if(this.preExecute) {
-			this.preExecute(entity);
-		}
 
 		if (this.assert) {
 			// If an assert function is defined, then use it to determine whether to attach a condition
@@ -104,5 +95,4 @@ export interface ConditionRuleOptions extends RuleOptions {
 	// the optional array of condition type sets to associate the condition with
 	sets?: ConditionTypeSet[];
 
-	preExecute?: (this: ConditionRule, entity: Entity) => void;
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -414,21 +414,21 @@ export class ModelSettings {
 	}
 }
 
-export class Standardize {
+export class Normalize {
 	// January 1st, 1970 at 12AM
 	private static JAN_01_1970 = new Date(18000000);
 
-	// Standardize the provided value based on the format specifier
+	// Normalize the provided value based on the format specifier
 	// so that it can be used appropriately for comparisons
-	static standardize(val: any, format: Format<any>) : any {
+	static normalize(val: any, format: Format<any>) : any {
 		if (!val && val !== false)
 			return val;
 
 		if (val.constructor.name === "Date") {
 			if (format.specifier === "t")
-				val = Standardize.date(val);
+				val = Normalize.date(val);
 			else if (format.specifier === "d")
-				val = Standardize.time(val);
+				val = Normalize.time(val);
 		}
 
 		return val;
@@ -436,10 +436,10 @@ export class Standardize {
 
 	// Set the date of the dateTime to January 1st, 1970
 	private static date(dateTime: Date): Date {
-		return Standardize._date(dateTime, Standardize.JAN_01_1970);
+		return Normalize._date(dateTime, Normalize.JAN_01_1970);
 	}
 
-	// Set the date of the dateTime to the supplied standardized date
+	// Set the date of the dateTime to the supplied normalized date
 	private static _date(dateTime: Date, standard: Date): Date {
 		const _dateTime = new Date(dateTime);
 		_dateTime.setMonth(standard.getMonth());
@@ -450,6 +450,6 @@ export class Standardize {
 
 	// Set the time of the dateTime to 12AM
 	private static time(dateTime: Date): Date {
-		return Standardize._date(Standardize.JAN_01_1970, dateTime);
+		return Normalize._date(Normalize.JAN_01_1970, dateTime);
 	}
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -414,28 +414,17 @@ export class ModelSettings {
 	}
 }
 
-export class Normalize {
+class Normalize {
 	// January 1st, 1970 at 12AM
 	private static JAN_01_1970 = new Date(18000000);
 
-	// Normalize the provided value based on the format specifier
-	// so that it can be used appropriately for comparisons
-	static normalize(val: any, format: Format<any>) : any {
-		if (!val && val !== false)
-			return val;
-
-		if (val.constructor.name === "Date") {
-			if (format.specifier === "t")
-				val = Normalize.date(val);
-			else if (format.specifier === "d")
-				val = Normalize.time(val);
-		}
-
-		return val;
+	// Set the time of the dateTime to 12AM
+	static time(dateTime: Date): Date {
+		return Normalize._date(Normalize.JAN_01_1970, dateTime);
 	}
 
 	// Set the date of the dateTime to January 1st, 1970
-	private static date(dateTime: Date): Date {
+	static date(dateTime: Date): Date {
 		return Normalize._date(dateTime, Normalize.JAN_01_1970);
 	}
 
@@ -447,9 +436,20 @@ export class Normalize {
 		_dateTime.setFullYear(standard.getFullYear());
 		return _dateTime ;
 	}
+};
+	
+// Normalize the provided value based on the format specifier
+// so that it can be used appropriately for comparisons
+export function normalize(val: any, format: Format<any>) : any {
+	if (!val && val !== false)
+		return val;
 
-	// Set the time of the dateTime to 12AM
-	private static time(dateTime: Date): Date {
-		return Normalize._date(Normalize.JAN_01_1970, dateTime);
+	if (val.constructor.name === "Date") {
+		if (format.specifier === "t")
+			val = Normalize.date(val);
+		else if (format.specifier === "d")
+			val = Normalize.time(val);
 	}
+
+	return val;
 };

--- a/src/model.ts
+++ b/src/model.ts
@@ -414,29 +414,17 @@ export class ModelSettings {
 	}
 }
 
-class Normalize {
-	// January 1st, 1970 at 12AM
-	private static JAN_01_1970 = new Date(18000000);
+// January 1st, 1970 at 12AM
+const JAN_01_1970 = new Date(18000000);
 
-	// Set the time of the dateTime to 12AM
-	static time(dateTime: Date): Date {
-		return Normalize._date(Normalize.JAN_01_1970, dateTime);
-	}
-
-	// Set the date of the dateTime to January 1st, 1970
-	static date(dateTime: Date): Date {
-		return Normalize._date(dateTime, Normalize.JAN_01_1970);
-	}
-
-	// Set the date of the dateTime to the supplied normalized date
-	private static _date(dateTime: Date, standard: Date): Date {
-		const _dateTime = new Date(dateTime);
-		_dateTime.setMonth(standard.getMonth());
-		_dateTime.setDate(standard.getDate());
-		_dateTime.setFullYear(standard.getFullYear());
-		return _dateTime ;
-	}
-};
+// Set the date of the dateTime to the supplied normalized date
+function normalizeDateTime(dateTime: Date, standard: Date): Date {
+	const _dateTime = new Date(dateTime);
+	_dateTime.setMonth(standard.getMonth());
+	_dateTime.setDate(standard.getDate());
+	_dateTime.setFullYear(standard.getFullYear());
+	return _dateTime ;
+}
 	
 // Normalize the provided value based on the format specifier
 // so that it can be used appropriately for comparisons
@@ -445,10 +433,14 @@ export function normalize(val: any, format: Format<any>) : any {
 		return val;
 
 	if (val.constructor.name === "Date") {
-		if (format.specifier === "t")
-			val = Normalize.date(val);
-		else if (format.specifier === "d")
-			val = Normalize.time(val);
+		if (format.specifier === "t") {
+			// Set the date of the dateTime to January 1st, 1970
+			val = normalizeDateTime(val, JAN_01_1970);
+		}
+		else if (format.specifier === "d") {
+			// Set the time of the dateTime to 12AM
+			val = normalizeDateTime(JAN_01_1970, val);
+		}
 	}
 
 	return val;

--- a/src/model.ts
+++ b/src/model.ts
@@ -413,3 +413,43 @@ export class ModelSettings {
 		this.useGlobalObject = config && !!config.useGlobalObject;
 	}
 }
+
+export class Standardize {
+	// January 1st, 1970 at 12AM
+	private static JAN_01_1970 = new Date(18000000);
+
+	// Standardize the provided value based on the format specifier
+	// so that it can be used appropriately for comparisons
+	static standardize(val: any, format: Format<any>) : any {
+		if (!val && val !== false)
+			return val;
+
+		if (val.constructor.name === "Date") {
+			if (format.specifier === "t")
+				val = Standardize.date(val);
+			else if (format.specifier === "d")
+				val = Standardize.time(val);
+		}
+
+		return val;
+	}
+
+	// Set the date of the dateTime to January 1st, 1970
+	private static date(dateTime: Date): Date {
+		return Standardize._date(dateTime, Standardize.JAN_01_1970);
+	}
+
+	// Set the date of the dateTime to the supplied standardized date
+	private static _date(dateTime: Date, standard: Date): Date {
+		const _dateTime = new Date(dateTime);
+		_dateTime.setMonth(standard.getMonth());
+		_dateTime.setDate(standard.getDate());
+		_dateTime.setFullYear(standard.getFullYear());
+		return _dateTime ;
+	}
+
+	// Set the time of the dateTime to 12AM
+	private static time(dateTime: Date): Date {
+		return Standardize._date(Standardize.JAN_01_1970, dateTime);
+	}
+};

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -2,6 +2,7 @@ import { ValidationRule, ValidationRuleOptions } from "./validation-rule";
 import { Property$format } from "./property";
 import { Entity } from "./entity";
 import { Type } from "./type";
+import { Format } from "./format";
 
 /**
  * A rule that validates that a property value is within a specific range
@@ -16,12 +17,19 @@ export class RangeRule extends ValidationRule {
 		// ensure the rule name is specified
 		options.name = options.name || "Range";
 
-		options.message = function(this: Entity): string {
-			var range: { min?: any; max?: any } = {};
+		options.message = function(this: Entity): string {			
+			let format = options.property.format;		
+			var val = RangeRule.standardize(options.property.value(this), format);
 
+			if (val == null) {
+				return null;
+			}	
+			
+			var range: { min?: any; max?: any } = {};
+				
 			if (options.min && options.min instanceof Function) {
 				try {
-					range.min = options.min.call(this);
+					range.min = RangeRule.standardize(options.min.call(this), format);					
 				}
 				catch (e) {
 					// Silently ignore min errors
@@ -30,20 +38,14 @@ export class RangeRule extends ValidationRule {
 
 			if (options.max && options.max instanceof Function) {
 				try {
-					range.max = options.max.call(this);
+					range.max = RangeRule.standardize(options.max.call(this), format);
 				}
 				catch (e) {
 					// Silently ignore max errors
 				}
 			}
 
-			var val = options.property.value(this);
-
-			if (val == null) {
-				return null;
-			}
-
-			if ((range.min == null || val >= range.min) && (range.max == null || val <= range.max)) {
+			if ((range.min == null || val >= range.min) && (range.max == null || val <= range.max)) {				
 				// Value is within range
 				return null;
 			}
@@ -71,6 +73,43 @@ export class RangeRule extends ValidationRule {
 	// get the string representation of the rule
 	toString(): string {
 		return `${this.property.containingType.fullName}.${this.property.name} in range, min: , max: `;
+	}
+
+	// January 1st, 1970 at 12AM
+	private static JAN_01_1970 = new Date(18000000);
+
+	// Standardize the provided value based on the format specifier
+	// so that it can be used appropriately for comparisons
+	private static standardize(val: any, format: Format<any>) : any {
+		if (!val && val !== false)
+			return val;
+
+		if (val.constructor.name === "Date") {
+			if (format.specifier === "t")
+				val = RangeRule.standardizeDate(val);
+			else if (format.specifier === "d")
+				val = RangeRule.standardizeTime(val);
+		}
+
+		return val;
+	}
+	
+	// Set the date of the dateTime to January 1st, 1970
+	private static standardizeDate(dateTime: Date): Date {
+		return RangeRule._standardizeDate(dateTime, RangeRule.JAN_01_1970);
+	}
+
+	// Set the date of the dateTime to the supplied standardized date
+	private static _standardizeDate(dateTime: Date, standard: Date): Date {			
+		dateTime.setMonth(standard.getMonth());
+		dateTime.setDate(standard.getDate());
+		dateTime.setFullYear(standard.getFullYear());
+		return dateTime;
+	}
+
+	// Set the time of the dateTime to 12AM	
+	private static standardizeTime(dateTime: Date): Date {
+		return RangeRule._standardizeDate(RangeRule.JAN_01_1970, dateTime);
 	}
 }
 

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -2,7 +2,7 @@ import { ValidationRule, ValidationRuleOptions } from "./validation-rule";
 import { Property$format } from "./property";
 import { Entity } from "./entity";
 import { Type } from "./type";
-import { Normalize } from "./model";
+import { normalize } from "./model";
 
 /**
  * A rule that validates that a property value is within a specific range
@@ -19,7 +19,7 @@ export class RangeRule extends ValidationRule {
 
 		options.message = function(this: Entity): string {			
 			let format = options.property.format;		
-			var val = Normalize.normalize(options.property.value(this), format);
+			var val = normalize(options.property.value(this), format);
 
 			if (val == null) {
 				return null;
@@ -29,7 +29,7 @@ export class RangeRule extends ValidationRule {
 				
 			if (options.min && options.min instanceof Function) {
 				try {
-					range.min = Normalize.normalize(options.min.call(this), format);					
+					range.min = normalize(options.min.call(this), format);					
 				}
 				catch (e) {
 					// Silently ignore min errors
@@ -38,7 +38,7 @@ export class RangeRule extends ValidationRule {
 	
 			if (options.max && options.max instanceof Function) {
 				try {
-					range.max = Normalize.normalize(options.max.call(this), format);
+					range.max = normalize(options.max.call(this), format);
 				}
 				catch (e) {
 					// Silently ignore max errors

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -25,25 +25,7 @@ export class RangeRule extends ValidationRule {
 				return null;
 			}	
 			
-			var range: { min?: any; max?: any } = {};
-				
-			if (options.min && options.min instanceof Function) {
-				try {
-					range.min = RangeRule.standardize(options.min.call(this), format);					
-				}
-				catch (e) {
-					// Silently ignore min errors
-				}
-			}
-
-			if (options.max && options.max instanceof Function) {
-				try {
-					range.max = RangeRule.standardize(options.max.call(this), format);
-				}
-				catch (e) {
-					// Silently ignore max errors
-				}
-			}
+			const range = RangeRule.getRange(this, options);
 
 			if ((range.min == null || val >= range.min) && (range.max == null || val <= range.max)) {				
 				// Value is within range
@@ -65,14 +47,46 @@ export class RangeRule extends ValidationRule {
 			else
 				return rootType.model.getResource("range-at-most").replace("{max}", Property$format(options.property, range.max) || range.max);
 		};
+		
+		options.preExecute = (entity) => {			
+			this["range"] = RangeRule.getRange(entity, options);
+		}
 
 		// call the base type constructor
 		super(rootType, options);
+
+		Object.defineProperty(this, "range", { value: null, writable: true });
 	}
 
 	// get the string representation of the rule
 	toString(): string {
 		return `${this.property.containingType.fullName}.${this.property.name} in range, min: , max: `;
+	}
+
+	private static getRange(entity: Entity, options: RangeRuleOptions) : Range
+	{
+		let format = options.property.format;		
+		let range: Range = { };
+				
+		if (options.min && options.min instanceof Function) {
+			try {
+				range["min"] = RangeRule.standardize(options.min.call(entity), format);					
+			}
+			catch (e) {
+				// Silently ignore min errors
+			}
+		}
+
+		if (options.max && options.max instanceof Function) {
+			try {
+				range["max"] = RangeRule.standardize(options.max.call(entity), format);
+			}
+			catch (e) {
+				// Silently ignore max errors
+			}
+		}
+
+		return range;
 	}
 
 	// January 1st, 1970 at 12AM
@@ -100,11 +114,12 @@ export class RangeRule extends ValidationRule {
 	}
 
 	// Set the date of the dateTime to the supplied standardized date
-	private static _standardizeDate(dateTime: Date, standard: Date): Date {			
-		dateTime.setMonth(standard.getMonth());
-		dateTime.setDate(standard.getDate());
-		dateTime.setFullYear(standard.getFullYear());
-		return dateTime;
+	private static _standardizeDate(dateTime: Date, standard: Date): Date {
+		let _dateTime = new Date(dateTime);
+		_dateTime.setMonth(standard.getMonth());
+		_dateTime.setDate(standard.getDate());
+		_dateTime.setFullYear(standard.getFullYear());
+		return _dateTime ;
 	}
 
 	// Set the time of the dateTime to 12AM	
@@ -116,4 +131,10 @@ export class RangeRule extends ValidationRule {
 export interface RangeRuleOptions extends ValidationRuleOptions {
 	min?: (this: Entity) => any;
 	max?: (this: Entity) => any;
+}
+
+interface Range
+{
+	min?: any;
+	max?: any;
 }

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -2,7 +2,7 @@ import { ValidationRule, ValidationRuleOptions } from "./validation-rule";
 import { Property$format } from "./property";
 import { Entity } from "./entity";
 import { Type } from "./type";
-import { Standardize } from "./model";
+import { Normalize } from "./model";
 
 /**
  * A rule that validates that a property value is within a specific range
@@ -19,7 +19,7 @@ export class RangeRule extends ValidationRule {
 
 		options.message = function(this: Entity): string {			
 			let format = options.property.format;		
-			var val = Standardize.standardize(options.property.value(this), format);
+			var val = Normalize.normalize(options.property.value(this), format);
 
 			if (val == null) {
 				return null;
@@ -29,7 +29,7 @@ export class RangeRule extends ValidationRule {
 				
 			if (options.min && options.min instanceof Function) {
 				try {
-					range.min = Standardize.standardize(options.min.call(this), format);					
+					range.min = Normalize.normalize(options.min.call(this), format);					
 				}
 				catch (e) {
 					// Silently ignore min errors
@@ -38,7 +38,7 @@ export class RangeRule extends ValidationRule {
 	
 			if (options.max && options.max instanceof Function) {
 				try {
-					range.max = Standardize.standardize(options.max.call(this), format);
+					range.max = Normalize.normalize(options.max.call(this), format);
 				}
 				catch (e) {
 					// Silently ignore max errors

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -2,7 +2,7 @@ import { ValidationRule, ValidationRuleOptions } from "./validation-rule";
 import { Property$format } from "./property";
 import { Entity } from "./entity";
 import { Type } from "./type";
-import { Format } from "./format";
+import { Standardize } from "./model";
 
 /**
  * A rule that validates that a property value is within a specific range
@@ -19,7 +19,7 @@ export class RangeRule extends ValidationRule {
 
 		options.message = function(this: Entity): string {			
 			let format = options.property.format;		
-			var val = RangeRule.standardize(options.property.value(this), format);
+			var val = Standardize.standardize(options.property.value(this), format);
 
 			if (val == null) {
 				return null;
@@ -29,16 +29,16 @@ export class RangeRule extends ValidationRule {
 				
 			if (options.min && options.min instanceof Function) {
 				try {
-					range.min = RangeRule.standardize(options.min.call(this), format);					
+					range["min"] = Standardize.standardize(options.min.call(this), format);					
 				}
 				catch (e) {
 					// Silently ignore min errors
 				}
 			}
-
+	
 			if (options.max && options.max instanceof Function) {
 				try {
-					range.max = RangeRule.standardize(options.max.call(this), format);
+					range["max"] = Standardize.standardize(options.max.call(this), format);
 				}
 				catch (e) {
 					// Silently ignore max errors
@@ -73,43 +73,6 @@ export class RangeRule extends ValidationRule {
 	// get the string representation of the rule
 	toString(): string {
 		return `${this.property.containingType.fullName}.${this.property.name} in range, min: , max: `;
-	}
-
-	// January 1st, 1970 at 12AM
-	private static JAN_01_1970 = new Date(18000000);
-
-	// Standardize the provided value based on the format specifier
-	// so that it can be used appropriately for comparisons
-	private static standardize(val: any, format: Format<any>) : any {
-		if (!val && val !== false)
-			return val;
-
-		if (val.constructor.name === "Date") {
-			if (format.specifier === "t")
-				val = RangeRule.standardizeDate(val);
-			else if (format.specifier === "d")
-				val = RangeRule.standardizeTime(val);
-		}
-
-		return val;
-	}
-	
-	// Set the date of the dateTime to January 1st, 1970
-	private static standardizeDate(dateTime: Date): Date {
-		return RangeRule._standardizeDate(dateTime, RangeRule.JAN_01_1970);
-	}
-
-	// Set the date of the dateTime to the supplied standardized date
-	private static _standardizeDate(dateTime: Date, standard: Date): Date {			
-		dateTime.setMonth(standard.getMonth());
-		dateTime.setDate(standard.getDate());
-		dateTime.setFullYear(standard.getFullYear());
-		return dateTime;
-	}
-
-	// Set the time of the dateTime to 12AM	
-	private static standardizeTime(dateTime: Date): Date {
-		return RangeRule._standardizeDate(RangeRule.JAN_01_1970, dateTime);
 	}
 }
 

--- a/src/range-rule.ts
+++ b/src/range-rule.ts
@@ -29,7 +29,7 @@ export class RangeRule extends ValidationRule {
 				
 			if (options.min && options.min instanceof Function) {
 				try {
-					range["min"] = Standardize.standardize(options.min.call(this), format);					
+					range.min = Standardize.standardize(options.min.call(this), format);					
 				}
 				catch (e) {
 					// Silently ignore min errors
@@ -38,7 +38,7 @@ export class RangeRule extends ValidationRule {
 	
 			if (options.max && options.max instanceof Function) {
 				try {
-					range["max"] = Standardize.standardize(options.max.call(this), format);
+					range.max = Standardize.standardize(options.max.call(this), format);
 				}
 				catch (e) {
 					// Silently ignore max errors


### PR DESCRIPTION
Standardize the datetime based on the format specifier so that it can be used appropriately for comparisons. When comparing time values, the date will be set to Jan 1 1970. When comparing date values, the time will be set to 12AM.
https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/12040/
**Important - Do not complete without reviewing the following PRs:**
- https://github.com/cognitoforms/VueModel/pull/8
- https://cognitoforms.visualstudio.com/Cognito%20Forms/_git/Cognito%20Forms/pullrequest/2339