### PR TITLE
fix: inconsistencies with existing vs new entity initialization

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -45,6 +45,7 @@ export class Entity {
 			this.meta = new ObjectMeta(type, this, id, isNew);
 
 			Object.defineProperty(this, "__fields__", { enumerable: false, configurable: false, writable: false, value: {} });
+			Object.defineProperty(this, "__pendingInit__", { enumerable: false, configurable: false, writable: false, value: {} });
 
 			// Register the newly constructed instance
 			type.register(this);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -54,7 +54,8 @@ export class Entity {
 				context = new InitializationContext(true);
 
 			// Initialize existing entity with provided property values
-			if (properties && (!isNew || isNested))
+			const shouldInit = !isNew || isNested;
+			if (shouldInit && properties)
 				this.init(properties, context);
 
 			// Raise the initNew or initExisting event on this type and all base types
@@ -67,7 +68,7 @@ export class Entity {
 				}
 
 				// Set values of new entity for provided properties
-				if (isNew && properties)
+				if (!shouldInit && properties)
 					this.set(properties);
 			});
 		}

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -45,7 +45,7 @@ export class Entity {
 			// If context was provided, it should be the last argument
 			context = arguments[arguments.length - 1];
 			if (!(context instanceof InitializationContext))
-				context = null;
+				context = new InitializationContext(isNew);
 
 			this.meta = new ObjectMeta(type, this, id, isNew);
 
@@ -54,9 +54,6 @@ export class Entity {
 
 			// Register the newly constructed instance
 			type.register(this);
-
-			if (!context)
-				context = new InitializationContext(isNew);
 
 			// Initialize existing entity with provided property values
 			if (!isNew && properties)

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -50,7 +50,7 @@ export class Entity {
 			// Register the newly constructed instance
 			type.register(this);
 
-			let isNested = !!context;
+			const isNested = !!context;
 			if (!context)
 				context = new InitializationContext(true);
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -41,7 +41,7 @@ export class Entity {
 				id = type.newId();
 				isNew = context ? context.isNewDocument : true;
 			}
-			
+
 			// If context was provided, it should be the last argument
 			context = arguments[arguments.length - 1];
 			if (!(context instanceof InitializationContext))

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -9,10 +9,18 @@ function resetModel() {
 	return new Model({
 		$namespace: Types as any,
 		Person: {
+			Id: {
+				identifier: true,
+				type: String
+			},
 			FirstName: String,
 			LastName: String
 		},
 		Movie: {
+			Id: {
+				identifier: true,
+				type: String
+			},
 			Title: String,
 			Director: "Person",
 			ReleaseDate: Date,
@@ -77,19 +85,19 @@ describe("Entity", () => {
 
 	describe("events", () => {
 		describe("property change is not raised when initializing existing entity", () => {
-			test("value property", () => {
+			test("value property", async () => {
 				const changed = jest.fn();
 				Types.Person.meta.getProperty("FirstName").changed.subscribe(changed);
 				Types.Person.meta.getProperty("LastName").changed.subscribe(changed);
-				new Types.Person("1", Alien.Director);
+				await Types.Person.meta.create({ Id: "1", ...Alien.Director });
 
 				expect(changed).not.toBeCalled();
 			});
 
-			test("value list property", () => {
+			test("value list property", async () => {
 				const changed = jest.fn();
 				Types.Movie.meta.getProperty("Genres").changed.subscribe(changed);
-				new Types.Movie("1", Alien);
+				await Types.Movie.meta.create({ Id: "1", ...Alien });
 
 				expect(changed).not.toBeCalled();
 			});
@@ -146,10 +154,11 @@ describe("Entity", () => {
 				expect(movie.serialize()).toEqual(Alien);
 			});
 
-			it("does not overwrite provided state of existing entity", () => {
-				const movie = new Types.Movie("1", Alien);
+			it("does not overwrite provided state of existing entity", async () => {
+				const state = { Id: "1", ...Alien };
+				const movie = await Types.Movie.meta.create(state);
 
-				expect(movie.serialize()).toEqual(Alien);
+				expect(movie.serialize()).toEqual(state);
 			});
 		});
 
@@ -177,11 +186,11 @@ describe("Entity", () => {
 				expect(movie.serialize()).toEqual(Alien);
 			});
 
-			it("does not overwrite initial state of existing entity", () => {
-				const movie = new Types.Movie("1", Alien);
+			it("does not overwrite initial state of existing entity", async () => {
+				const state = { Id: "1", ...Alien };
+				const movie = await Types.Movie.meta.create(state);
 
-				const state = movie.serialize();
-				expect(state).toEqual(Alien);
+				expect(movie.serialize()).toEqual(state);
 			});
 		});
 	});

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -62,13 +62,13 @@ describe("globalize", function () {
 
 	describe("parseNumber", () => {
 		test("parseNumber('#.##')", () => {
-			expect(parseNumber("3.14", CultureInfo.CurrentCulture)).toBe(3.14);
+			expect(parseNumber("3.14", "Number", CultureInfo.CurrentCulture)).toBe(3.14);
 		});
 		test("parseNumber('#.#')", () => {
-			expect(parseNumber("3.1", CultureInfo.CurrentCulture)).toBe(3.1);
+			expect(parseNumber("3.1", "Number", CultureInfo.CurrentCulture)).toBe(3.1);
 		});
 		test("parseNumber('#')", () => {
-			expect(parseNumber("3", CultureInfo.CurrentCulture)).toBe(3);
+			expect(parseNumber("3", "Number", CultureInfo.CurrentCulture)).toBe(3);
 		});
 	});
 });

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -36,4 +36,8 @@ export class InitializationContext {
 			this.wait(task);
 		return task;
 	}
+
+	get isConstructorCall() {
+		return this.constructorCall;
+	}
 }

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -4,13 +4,13 @@ import { Property } from "./property";
 export type InitializationValueResolver = (instance: Entity, property: Property, value: any) => Promise<any>;
 
 export class InitializationContext {
-	private constructorCall = false;
+	private newDocument = false;
 	private valueResolver: InitializationValueResolver;
 	private tasks = new Set<Promise<any>>();
 	private waiting: (() => void)[] = [];
 
-	constructor(constructorCall: boolean, valueResolver?: InitializationValueResolver) {
-		this.constructorCall = constructorCall;
+	constructor(newDocument: boolean, valueResolver?: InitializationValueResolver) {
+		this.newDocument = newDocument;
 		this.valueResolver = valueResolver;
 	}
 
@@ -37,7 +37,7 @@ export class InitializationContext {
 		return task;
 	}
 
-	get isConstructorCall() {
-		return this.constructorCall;
+	get isNewDocument() {
+		return this.newDocument;
 	}
 }

--- a/src/object-meta.ts
+++ b/src/object-meta.ts
@@ -10,7 +10,7 @@ export class ObjectMeta {
 	readonly type: Type;
 	readonly entity: Entity;
 
-	readonly __pendingInvocation__: Rule[];
+	readonly __pendingInvocation__: Rule[] = [];
 
 	id: string;
 	isNew: boolean;

--- a/src/property.ts
+++ b/src/property.ts
@@ -1,9 +1,9 @@
 import { Event, EventSubscriber, EventPublisher } from "./events";
-import { Entity, EntityConstructorForType, EntityChangeEventArgs, EntityAccessEventArgs } from "./entity";
+import { Entity, EntityChangeEventArgs, EntityAccessEventArgs } from "./entity";
 import { Format } from "./format";
 import { Type, PropertyType, isEntityType, Value, isValue, isValueArray } from "./type";
 import { PropertyChain } from "./property-chain";
-import { getTypeName, getDefaultValue, parseFunctionName, ObjectLookup, merge, getConstructorName, isType } from "./helpers";
+import { getTypeName, getDefaultValue, parseFunctionName, ObjectLookup, merge, getConstructorName, isType, flatMap } from "./helpers";
 import { ObservableArray, updateArray } from "./observable-array";
 import { Rule, RuleOptions } from "./rule";
 import { CalculatedPropertyRule } from "./calculated-property-rule";
@@ -17,7 +17,6 @@ import { StringLengthRule } from "./string-length-rule";
 import { ListLengthRule } from "./list-length-rule";
 import { InitializationContext } from "./initilization-context";
 import { ConditionType, ErrorConditionType } from "./condition-type";
-import { flatMap } from "./helpers";
 
 export class Property implements PropertyPath {
 	readonly containingType: Type;

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -1,0 +1,30 @@
+/* eslint-disable no-new */
+import { Model } from "./model";
+import { Entity, EntityConstructorForType } from "./entity";
+
+describe("Property", () => {
+	it("can have a constant value", async () => {
+		const model = new Model({
+			Skill: {
+				Name: String,
+				Proficiency: Number
+			},
+			Person: {
+				Age: {
+					type: "Number[]",
+					constant: [50, 100]
+				},
+				Skills: {
+					type: "Skill[]",
+					constant: [{
+						Name: "Climbing",
+						Proficiency: 4
+					}]
+				}
+			}
+		});
+		// const instance = await model.types.Person.create({});
+		const instance = new model.types.Person.jstype();
+		expect(instance.serialize()).toEqual({ Skills: [{ Name: "Climbing", Proficiency: 4 }] });
+	});
+});

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -1,19 +1,17 @@
 /* eslint-disable no-new */
 import { Model } from "./model";
-import { Entity, EntityConstructorForType } from "./entity";
 
 describe("Property", () => {
 	it("can have a constant value", async () => {
 		const model = new Model({
 			Skill: {
 				Name: String,
-				Proficiency: Number
+				Proficiency: {
+					default() { return null; },
+					type: Number
+				}
 			},
 			Person: {
-				Age: {
-					type: "Number[]",
-					constant: [50, 100]
-				},
 				Skills: {
 					type: "Skill[]",
 					constant: [{
@@ -23,8 +21,7 @@ describe("Property", () => {
 				}
 			}
 		});
-		// const instance = await model.types.Person.create({});
-		const instance = new model.types.Person.jstype();
-		expect(instance.serialize()).toEqual({ Skills: [{ Name: "Climbing", Proficiency: 4 }] });
+		const instance = await model.types.Person.create({}) as any;
+		expect(instance.Skills[0].Proficiency).toBe(4);
 	});
 });

--- a/src/type.ts
+++ b/src/type.ts
@@ -117,7 +117,8 @@ export class Type {
 			instance.set(state);
 			return new Promise(resolve => resolve(instance));
 		}
-		const context = new InitializationContext(!id, valueResolver);
+		const isNew = !id;
+		const context = new InitializationContext(isNew, valueResolver);
 		// Cast the jstype to any so we can call the internal constructor signature that takes a context
 		// We don't want to put the context on the public constructor interface
 		const Ctor = this.jstype as any;
@@ -569,7 +570,7 @@ export function isEntityType(type: any): type is EntityType {
 	return type.meta && type.meta instanceof Type;
 }
 
-export function getIdFromState(type: Type, state: any): string {
+export function getIdFromState(type: Type, state: any): string | undefined {
 	if (type.identifier && typeof state === "object") {
 		const id: any = state[type.identifier.name];
 		if (id && typeof id === "string" && id.length > 0)

--- a/src/type.ts
+++ b/src/type.ts
@@ -23,7 +23,7 @@ export class Type {
 	readonly baseType: Type;
 	readonly derivedTypes: Type[];
 
-	identifier: Property;
+	private _identifier: Property;
 
 	// Backing fields for properties that are settable and also derived from
 	// other data, calculated in some way, or cannot simply be changed
@@ -47,7 +47,7 @@ export class Type {
 		this.jstype = Type$generateConstructor(this, fullName, baseType, model.settings.useGlobalObject ? getGlobalObject() : null);
 		this.baseType = baseType;
 		this.derivedTypes = [];
-		this.identifier = null;
+		this._identifier = null;
 
 		Object.defineProperty(this, "__pool__", { enumerable: false, configurable: false, writable: false, value: {} });
 		Object.defineProperty(this, "__properties__", { enumerable: false, configurable: false, writable: false, value: {} });
@@ -80,6 +80,16 @@ export class Type {
 			this.extend(options);
 	}
 
+	get identifier() {
+		if (this._identifier)
+			return this._identifier;
+		return this.baseType ? this.baseType.identifier : null;
+	}
+
+	set identifier(val) {
+		this._identifier = val;
+	}
+
 	createSync(state: any): Entity {
 		// Attempt to fetch an existing instance if the state contains an Id property
 		const id = getIdFromState(this, state);
@@ -90,8 +100,9 @@ export class Type {
 				instance.set(state);
 				return instance;
 			}
+			const Ctor = this.jstype as any;
 			// Construct an instance using the known id
-			return new this.jstype(id, state);
+			return new Ctor(id, state);
 		}
 		// Construct a new instance without a known id
 		return new this.jstype(state);
@@ -99,18 +110,14 @@ export class Type {
 
 	create(state: any, valueResolver?: InitializationValueResolver): Promise<Entity> {
 		// Attempt to fetch an existing instance if the state contains an Id property
-		let id: string = null;
-		let instance: Entity;
-		if (state && state.Id && typeof state.Id === "string" && state.Id.length > 0) {
-			id = state.Id;
-			instance = this.get(id);
-			if (instance) {
-				// Assign state to the existing object
-				instance.set(state);
-				return new Promise(resolve => resolve(instance));
-			}
+		const id = getIdFromState(this, state);
+		let instance = id && this.get(id);
+		if (instance) {
+			// Assign state to the existing object
+			instance.set(state);
+			return new Promise(resolve => resolve(instance));
 		}
-		const context = new InitializationContext(false, valueResolver);
+		const context = new InitializationContext(!id, valueResolver);
 		// Cast the jstype to any so we can call the internal constructor signature that takes a context
 		// We don't want to put the context on the public constructor interface
 		const Ctor = this.jstype as any;

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -1,0 +1,19 @@
+import { Model } from "./model";
+
+describe("Type", () => {
+	test("identifier property is inherited from baseType", () => {
+		const model = new Model({
+			Base: {
+				Id: {
+					identifier: true,
+					type: String
+				}
+			},
+			Sub: {
+				$extends: "Base"
+			}
+		});
+        
+		expect(model.types.Sub.identifier).toBe(model.types.Base.identifier);
+	});
+});


### PR DESCRIPTION
- add `isNewDocument` property to `InitializationContext`
  - this will determine whether nested objects without identifiers in an initializing object graph are considered _new_ or not
- remove `id` from public entity constructor (`EntityConstructorForType<T>`)
- simplify `Entity` constructor to use only the `isNew` variable in deciding whether to call `init()` or `set()`
- ensure `Entity.__pendingInit__` property is initialized
- add some tests, fix some tests