### PR TITLE
feat: option to override source of dynamic property label

### DIFF
--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -7,7 +7,7 @@ import { Format } from "./format";
 
 /**
  * Encapsulates the logic required to work with a chain of properties and
- * a root object, allowing interaction with the chain as if it were a 
+ * a root object, allowing interaction with the chain as if it were a
  * single property of the root object.
  */
 export class PropertyChain implements PropertyPath {
@@ -275,6 +275,10 @@ export class PropertyChain implements PropertyPath {
 
 	get label(): string {
 		return this.lastProperty.label;
+	}
+
+	get labelSource(): PropertyPath {
+		return this.lastProperty.labelSource;
 	}
 
 	get labelIsFormat(): boolean {

--- a/src/property-path.ts
+++ b/src/property-path.ts
@@ -16,6 +16,7 @@ export interface PropertyPath {
 	readonly lastProperty: Property;
 
 	label: string;
+	labelSource: PropertyPath;
 	readonly labelIsFormat: boolean;
 	helptext: string;
 	readonly helptextIsFormat: boolean;

--- a/src/property.ts
+++ b/src/property.ts
@@ -27,6 +27,7 @@ export class Property implements PropertyPath {
 
 	constant: any;
 	label: string;
+	labelSource: PropertyPath;
 	helptext: string;
 	isCalculated: boolean;
 	format: Format<any>;
@@ -128,6 +129,16 @@ export class Property implements PropertyPath {
 				this.label = options.label;
 			else if (!this.label)
 				this.label = this.name.replace(/(^[a-z]+|[A-Z]{2,}(?=[A-Z][a-z]|$)|[A-Z][a-z]*)/g, " $1").trim();
+
+			// Label Source
+			if (options.labelSource) {
+				if (typeof (options.labelSource) !== "string")
+					throw new Error(`Invalid labelSource property for '${this}.`);
+
+				targetType.model.ready(() => {
+					this.labelSource = targetType.getPath(options.labelSource);
+				});
+			}
 
 			// Helptext
 			this.helptext = options.helptext;
@@ -592,6 +603,11 @@ export interface PropertyOptions {
 	*  The property name will be used as the label when not specified.
 	*/
 	label?: string;
+
+	/**
+	 * The optional path to use for the source of the property's label, if it contains format tokens
+	 */
+	labelSource?: string;
 
 	/** The optional helptext for the property */
 	helptext?: string;

--- a/src/property.ts
+++ b/src/property.ts
@@ -738,6 +738,48 @@ export interface PropertyRuleOptions extends RuleOptions {
 
 }
 
+/**
+ * Gets a format object for the given property's label, if it is dynamic (i.e. contains format tokens)
+ */
+export function getLabelFormat(property: PropertyPath): Format<Entity> | undefined {
+	if (property.label && property.labelIsFormat) {
+		const labelSourceType = getLabelSourceType(property);
+		return labelSourceType.model.getFormat<Entity>(labelSourceType.jstype, property.label);
+	}
+}
+
+/**
+ * Gets the model type of the source object that should be used to evaluate the
+ * property's label, if it is dynamic (i.e. contains format tokens)
+ */
+export function getLabelSourceType(property: PropertyPath): Type {
+	// If a label source is specified, then determine it's model type
+	if (property.labelSource) {
+		const labelSourceType = property.labelSource.propertyType;
+		if (isEntityType(labelSourceType))
+			return labelSourceType.meta;
+	}
+
+	return property.containingType;
+}
+
+/**
+ * Evaluates the given property's label, using the given entity as context if the label is dynamic (i.e. contains format tokens)
+ */
+export function evaluateLabel(property: PropertyPath, entity: Entity): string {
+	if (property.labelIsFormat) {
+		let labelFormat = getLabelFormat(property);
+		let labelFormatInstance = entity;
+		if (property.labelSource) {
+			labelFormatInstance = property.labelSource.value(entity);
+		}
+		return labelFormat.convert(labelFormatInstance);
+	}
+	else {
+		return property.label;
+	}
+}
+
 export function Property$format(prop: Property, val: any): string {
 	if (prop.format) {
 		return prop.format.convert(val);

--- a/src/property.ts
+++ b/src/property.ts
@@ -768,7 +768,7 @@ export function getLabelSourceType(property: PropertyPath): Type {
  */
 export function evaluateLabel(property: PropertyPath, entity: Entity): string {
 	if (property.labelIsFormat) {
-		let labelFormat = getLabelFormat(property);
+		const labelFormat = getLabelFormat(property);
 		let labelFormatInstance = entity;
 		if (property.labelSource) {
 			labelFormatInstance = property.labelSource.value(entity);

--- a/src/validation-rule.ts
+++ b/src/validation-rule.ts
@@ -1,7 +1,7 @@
 import { ConditionRule, ConditionRuleOptions } from "./condition-rule";
 import { PropertyRule, Property, PropertyRuleOptions, getLabelSourceType, getLabelFormat, evaluateLabel } from "./property";
 import { Entity } from "./entity";
-import { Type, isEntityType } from "./type";
+import { Type } from "./type";
 
 export class ValidationRule extends ConditionRule implements PropertyRule {
 	property: Property;

--- a/src/validation-rule.ts
+++ b/src/validation-rule.ts
@@ -36,8 +36,8 @@ export class ValidationRule extends ConditionRule implements PropertyRule {
 		if (options.message && (typeof options.message === "function" || (typeof options.message === "string" && options.message.indexOf("{property}") >= 0))) {
 			// Property label with dynamic format tokens
 			if (property.labelIsFormat) {
-				let labelSourceType = getLabelSourceType(property);
-				let labelFormat = getLabelFormat(property);
+				const labelSourceType = getLabelSourceType(property);
+				const labelFormat = getLabelFormat(property);
 
 				// ensure tokens included in the format trigger rule execution
 				labelFormat.paths.forEach(p => {

--- a/src/validation-rule.unit.ts
+++ b/src/validation-rule.unit.ts
@@ -19,4 +19,77 @@ describe("validation-rule", () => {
 		const instance = new model.types.Test.jstype();
 		expect(instance.meta.conditions.length).toBe(0);
 	});
+	test("property label included in error message", () => {
+		const model = new Model({
+			Test: {
+				Prop: {
+					type: String,
+					error: {
+						dependsOn: "",
+						function() {
+							return "Property {property} is not valid";
+						}
+					}
+				}
+			}
+		});
+
+		const instance = new model.types.Test.jstype();
+		expect(instance.meta.conditions.length).toBe(1);
+		expect(instance.meta.conditions[0].condition.message).toBe("Property Prop is not valid");
+	});
+	test("property label included in error message can be dynamic", () => {
+		const model = new Model({
+			Test: {
+				Number: Number,
+				Prop: {
+					type: String,
+					label: "Prop [Number]",
+					error: {
+						dependsOn: "",
+						function() {
+							return "Property {property} is not valid";
+						}
+					}
+				}
+			}
+		});
+
+		const instance = new model.types.Test.jstype({ Number: 1 });
+		expect(instance.meta.conditions.length).toBe(1);
+		expect(instance.meta.conditions[0].condition.message).toBe("Property Prop 1 is not valid");
+		(instance as any).Number = 2;
+		expect(instance.meta.conditions[0].condition.message).toBe("Property Prop 2 is not valid");
+	});
+	test("property label included in error message can be dynamic and use a custom source", () => {
+		const model = new Model({
+			Parent: {
+				Name: String
+			},
+			Test: {
+				Number: Number,
+				Parent: {
+					type: "Parent"
+				},
+				Prop: {
+					type: String,
+					label: "Prop owned by [Name]",
+					labelSource: "Parent",
+					error: {
+						dependsOn: "",
+						function() {
+							return "Property {property} is not valid";
+						}
+					}
+				}
+			}
+		});
+
+		const parentInstance = new model.types.Parent.jstype({ Name: "Parent Object" });
+		const instance = new model.types.Test.jstype({ Number: 1, Parent: parentInstance });
+		expect(instance.meta.conditions.length).toBe(1);
+		expect(instance.meta.conditions[0].condition.message).toBe("Property Prop owned by Parent Object is not valid");
+		(instance as any).Parent.Name = "New Parent Object";
+		expect(instance.meta.conditions[0].condition.message).toBe("Property Prop owned by New Parent Object is not valid");
+	});
 });


### PR DESCRIPTION
- Add `labelSource` to property options
- Export helper functions for working with dynamic property labels: `getLabelFormat`, `getLabelSourceType`, and `evaluateLabel`
- In validation rule, consider label source when configuring rule inputs and use helper functions to evaluate the property's dynamic label