### PR TITLE
feat: asynchronous Entity.set when calling Type.create

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -160,14 +160,11 @@ export class Entity {
 		for (let [propName, state] of Entity.getSortedPropertyData(properties)) {
 			const prop = this.serializer.resolveProperty(this, propName);
 			if (prop) {
-				if (this._context) {
-					const valueResolution = this._context.tryResolveValue(this, prop, state);
-					if (valueResolution) {
-						valueResolution.then(asyncState => this.setProp(prop, asyncState));
-						continue;
-					}
-				}
-				this.setProp(prop, state);
+				const valueResolution = this._context ? this._context.tryResolveValue(this, prop, state) : null;
+				if (valueResolution)
+					valueResolution.then(asyncState => this.setProp(prop, asyncState));
+				else
+					this.setProp(prop, state);
 			}
 		}
 	}

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -184,21 +184,24 @@ export class Entity {
 						// If the item is an object that has an Id property, then retrieve or create an object with that Id
 						if (!(s instanceof ChildEntity) && typeof s === "object" && getIdFromState(ChildEntity.meta, s)) {
 							const id = getIdFromState(ChildEntity.meta, s);
-							if (id && ChildEntity.meta.get(id))
-								ChildEntity.meta.get(id).withContext(this._context, entity => entity.set(state));
+							if (id && ChildEntity.meta.get(id)) {
+								ChildEntity.meta.get(id).withContext(this._context, entity => entity.set(s));
+								s = null;
+							}
 							else
 								s = new (ChildEntity as any)(id, s, this._context);
 						}
+
 						if (s instanceof ChildEntity)
 							state.splice(idx, 1, s);
-						else
+						else if (s)
 							currentValue[idx].withContext(this._context, entity => entity.set(s));
 					}
 					// Add a list item
 					else if (s instanceof ChildEntity)
 						currentValue.push(s);
 					else
-						currentValue.push(ChildEntity.meta.createSync(s));
+						currentValue.push(new (ChildEntity as any)(s, this._context));
 				});
 			}
 			else if (state instanceof ChildEntity)

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -190,7 +190,7 @@ export class Entity {
 							if (id && ChildEntity.meta.get(id))
 								ChildEntity.meta.get(id).withContext(this._context, entity => entity.set(state));
 							else
-								s = new (ChildEntity as any)(s, this._context);
+								s = new (ChildEntity as any)(id, s, this._context);
 						}
 						if (s instanceof ChildEntity)
 							state.splice(idx, 1, s);

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -188,14 +188,14 @@ export class Entity {
 						}
 						else if (s instanceof ChildEntity)
 							currentValue.splice(idx, 1, s);
-						else if (s)
-							currentValue[idx].withContext(this._context, entity => entity.set(s));
+						else
+							console.warn("Provided state,", s, ", is not valid for type " + ChildEntity.meta.fullName + "[].");
 					}
 					// Add a list item
 					else if (s instanceof ChildEntity)
 						currentValue.push(s);
 					else
-						currentValue.push(new (ChildEntity as any)(s, this._context));
+						currentValue.push(Type$createOrUpdate(ChildEntity.meta, s, this._context).instance);
 				});
 			}
 			else if (state instanceof ChildEntity)
@@ -216,7 +216,7 @@ export class Entity {
 				// Got something other than an object, so just use it and expect to get a down-stream error
 				else if (typeof state !== "object")
 					value = state;
-				else if (currentValue)
+				else if (currentValue && !getIdFromState(ChildEntity.meta, state))
 					currentValue.withContext(this._context, entity => entity.set(state));
 				// Got an object, so attempt to fetch or create and assign the state
 				else

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -129,8 +129,15 @@ export class Entity {
 	}
 
 	withContext(context: InitializationContext, action: (entity: Entity) => void) {
-		this._context = context;
+		// Don't overwrite existing context
+		if (!this._context)
+			this._context = context;
+		// Ensure provided context waits on the existing context to be ready
+		else
+			context.wait(new Promise(resolve => this._context.ready(resolve)));
+
 		action(this);
+
 		if (context !== null) {
 			context.ready(() => {
 				this._context = null;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -16,6 +16,7 @@ export class Entity {
 
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgs>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgs>;
+	private _context: InitializationContext = null;
 
 	constructor(); // Prototype assignment *** used internally
 	constructor(type: Type, id: string, properties?: ObjectLookup<any>, context?: InitializationContext); // Construct existing instance with state
@@ -91,13 +92,10 @@ export class Entity {
 		let properties: ObjectLookup<any>;
 
 		// Convert property/value pair to a property dictionary
-		if (typeof property === "string") {
-			properties = {};
-			properties[property] = value;
-		}
-		else {
+		if (typeof property === "string")
+			properties = { [property]: value };
+		else
 			properties = property;
-		}
 
 		const initializedProps = new Set<Property>();
 		// Initialize the specified properties
@@ -130,86 +128,112 @@ export class Entity {
 		Property$init(prop, this, value);
 	}
 
+	withContext(context: InitializationContext, action: (entity: Entity) => void) {
+		this._context = context;
+		action(this);
+		if (context !== null) {
+			context.ready(() => {
+				this._context = null;
+			});
+		}
+	}
+
 	set(properties: ObjectLookup<any>): void;
 	set(property: string, value: any): void;
 	set(property: any, value?: any): void {
 		let properties: ObjectLookup<any>;
 
 		// Convert property/value pair to a property dictionary
-		if (typeof property === "string") {
-			properties = {};
-			properties[property] = value;
-		}
-		else {
+		if (typeof property === "string")
+			properties = { [property]: value };
+		else
 			properties = property;
-		}
 
 		// Set the specified properties
 		for (let [propName, state] of Entity.getSortedPropertyData(properties)) {
 			const prop = this.serializer.resolveProperty(this, propName);
 			if (prop) {
-				let value;
-				const currentValue = prop.value(this);
-				if (isEntityType(prop.propertyType)) {
-					const ChildEntity = prop.propertyType;
-					if (prop.isList && Array.isArray(state) && Array.isArray(currentValue)) {
-						state.forEach((s, idx) => {
-							if (!(s instanceof ChildEntity))
-								s = this.serializer.deserialize(this, s, prop, null, false);
-
-							// Modifying/replacing existing list item
-							if (idx < currentValue.length) {
-								// If the item is an object that has an Id property, then retrieve or create an object with that Id
-								if (!(s instanceof ChildEntity) && typeof s === "object" && getIdFromState(ChildEntity.meta, s))
-									s = ChildEntity.meta.createSync(s);
-								if (s instanceof ChildEntity)
-									state.splice(idx, 1, s);
-								else
-									currentValue[idx].set(s);
-							}
-							// Add a list item
-							else if (s instanceof ChildEntity)
-								currentValue.push(s);
-							else
-								currentValue.push(ChildEntity.meta.createSync(s));
-						});
-					}
-					else if (state instanceof ChildEntity)
-						value = state;
-					else if (state == null)
-						value = null;
-					else {
-						// Attempt to deserialize the state
-						let newState = this.serializer.deserialize(this, state, prop, null, false);
-						if (typeof newState !== "undefined")
-							state = newState;
-						// Got null, so assign null to the property
-						if (state == null)
-							value = null;
-						// Got a valid instance, so use it
-						else if (state instanceof ChildEntity)
-							value = state;
-						// Got something other than an object, so just use it and expect to get a down-stream error
-						else if (typeof state !== "object")
-							value = state;
-						// Got an object, so attempt to fetch or create and assign the state
-						else if (getIdFromState(ChildEntity.meta, state))
-							value = ChildEntity.meta.createSync(state);
-						else if (currentValue)
-							currentValue.set(state);
-						else
-							value = new ChildEntity(state);
+				if (this._context) {
+					const valueResolution = this._context.tryResolveValue(this, prop, state);
+					if (valueResolution) {
+						valueResolution.then(asyncState => this.setProp(prop, asyncState));
+						continue;
 					}
 				}
-				else if (prop.isList && Array.isArray(state) && Array.isArray(currentValue))
-					currentValue.splice(0, currentValue.length, ...state.map(s => this.serializer.deserialize(this, s, prop, null)));
-				else
-					value = this.serializer.deserialize(this, state, prop, null);
-
-				if (value !== undefined)
-					Property$setter(prop, this, value);
+				this.setProp(prop, state);
 			}
 		}
+	}
+
+	private setProp(prop: Property, state: any) {
+		let value;
+		const currentValue = prop.value(this);
+		if (isEntityType(prop.propertyType)) {
+			const ChildEntity = prop.propertyType;
+			if (prop.isList && Array.isArray(state) && Array.isArray(currentValue)) {
+				state.forEach((s, idx) => {
+					if (!(s instanceof ChildEntity))
+						s = this.serializer.deserialize(this, s, prop, this._context, false);
+
+					// Modifying/replacing existing list item
+					if (idx < currentValue.length) {
+						// If the item is an object that has an Id property, then retrieve or create an object with that Id
+						if (!(s instanceof ChildEntity) && typeof s === "object" && getIdFromState(ChildEntity.meta, s)) {
+							const id = getIdFromState(ChildEntity.meta, s);
+							if (id && ChildEntity.meta.get(id))
+								ChildEntity.meta.get(id).withContext(this._context, entity => entity.set(state));
+							else
+								s = new (ChildEntity as any)(s, this._context);
+						}
+						if (s instanceof ChildEntity)
+							state.splice(idx, 1, s);
+						else
+							currentValue[idx].withContext(this._context, entity => entity.set(s));
+					}
+					// Add a list item
+					else if (s instanceof ChildEntity)
+						currentValue.push(s);
+					else
+						currentValue.push(ChildEntity.meta.createSync(s));
+				});
+			}
+			else if (state instanceof ChildEntity)
+				value = state;
+			else if (state == null)
+				value = null;
+			else {
+				// Attempt to deserialize the state
+				let newState = this.serializer.deserialize(this, state, prop, this._context, false);
+				if (typeof newState !== "undefined")
+					state = newState;
+				// Got null, so assign null to the property
+				if (state == null)
+					value = null;
+				// Got a valid instance, so use it
+				else if (state instanceof ChildEntity)
+					value = state;
+				// Got something other than an object, so just use it and expect to get a down-stream error
+				else if (typeof state !== "object")
+					value = state;
+				else if (currentValue)
+					currentValue.withContext(this._context, entity => entity.set(state));
+				// Got an object, so attempt to fetch or create and assign the state
+				else {
+					const id = getIdFromState(ChildEntity.meta, state);
+					if (id && ChildEntity.meta.get(id))
+						ChildEntity.meta.get(id).withContext(this._context, entity => entity.set(state));
+					else
+						value = new (ChildEntity as any)(id, state, this._context);
+				}
+			}
+		}
+		else if (prop.isList && Array.isArray(state) && Array.isArray(currentValue))
+			currentValue.splice(0, currentValue.length, ...state.map(s => this.serializer.deserialize(this, s, prop, this._context)));
+		else
+			value = this.serializer.deserialize(this, state, prop, this._context);
+
+		if (value !== undefined)
+			Property$setter(prop, this, value);
 	}
 
 	get(property: string): any {

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -125,7 +125,8 @@ export class Entity {
 
 		value = this.serializer.deserialize(this, state, prop, context);
 
-		Property$init(prop, this, value);
+		if (value !== undefined)
+			Property$init(prop, this, value);
 	}
 
 	withContext(context: InitializationContext, action: (entity: Entity) => void) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -110,21 +110,7 @@ export class Type {
 
 	create(state: any, valueResolver?: InitializationValueResolver): Promise<Entity> {
 		// Attempt to fetch an existing instance if the state contains an Id property
-		const id = getIdFromState(this, state);
-		const isNew = !id;
-		const context = new InitializationContext(isNew, valueResolver);
-		let instance = id && this.get(id);
-		if (instance) {
-			// Assign state to the existing object
-			instance.withContext(context, () => instance.set(state));
-		}
-		else {
-			// Cast the jstype to any so we can call the internal constructor signature that takes a context
-			// We don't want to put the context on the public constructor interface
-			const Ctor = this.jstype as any;
-			// Construct an instance using the known id if it is present
-			instance = (id ? new Ctor(id, state, context) : new Ctor(state, context)) as Entity;
-		}
+		const { context, instance } = Type$createOrUpdate(this, state, valueResolver);
 		return new Promise(resolve => context.ready(() => resolve(instance)));
 	}
 
@@ -508,6 +494,30 @@ export class Type {
 			}
 		});
 	}
+}
+
+export function Type$createOrUpdate(type: Type, state: any, contextOrResolver: InitializationValueResolver | InitializationContext) {
+	const id = getIdFromState(type, state);
+	const isNew = !id;
+	let context: InitializationContext;
+	if (contextOrResolver instanceof InitializationContext)
+		context = contextOrResolver;
+	else
+		context = new InitializationContext(isNew, contextOrResolver);
+
+	let instance = id && type.get(id);
+	if (instance) {
+		// Assign state to the existing object
+		instance.withContext(context, () => instance.set(state));
+	}
+	else {
+		// Cast the jstype to any so we can call the internal constructor signature that takes a context
+		// We don't want to put the context on the public constructor interface
+		const Ctor = type.jstype as any;
+		// Construct an instance using the known id if it is present
+		instance = (id ? new Ctor(id, state, context) : new Ctor(state, context)) as Entity;
+	}
+	return { context, instance };
 }
 
 export type Value = string | number | Date | boolean;


### PR DESCRIPTION
Because `Type.create()` may update the pooled entity using `set()`, if the provided state includes values that must be asynchronously resolved, an error would be thrown because async value resolution was only supported by `Entity.init()`. This change introduces a way to provide an `InitializationContext` and perform an action on an `Entity`, allowing us to effectively support async `set()`.

```ts
entity.withContext(context, e => e.set(state));
```