### PR TITLE
fix: remove references to remove/removeAt functions

### DIFF
--- a/src/observable-array.ts
+++ b/src/observable-array.ts
@@ -566,15 +566,7 @@ function observableSplice(arr: any[], events: any[], index: number, removeCount:
 	let arr2 = arr as any;
 
 	if (removeCount) {
-		if (removeCount > 1 && arr2.removeRange) {
-			removedItems = arr2.removeRange(index, removeCount);
-		}
-		else if (removeCount === 1 && arr2.remove) {
-			removedItems = [arr2.removeAt(index)];
-		}
-		else {
-			removedItems = arr.splice(index, removeCount);
-		}
+		removedItems = arr.splice(index, removeCount);
 	
 		if (events) {
 			events.push({


### PR DESCRIPTION
These references to `remove` and `removeAt` look to be carry over from ExoWeb, and one of the if clauses was causing an error due to checking for the existence of the `remove` function and then trying to call `removeAt`.