### PR TITLE
fix: ignore calculated/constant properties when calling entity set/init

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -101,7 +101,7 @@ export class Entity {
 		// Initialize the specified properties
 		for (const [propName, state] of Entity.getSortedPropertyData(properties)) {
 			const prop = this.serializer.resolveProperty(this, propName);
-			if (prop) {
+			if (prop && !prop.isCalculated && !prop.isConstant) {
 				initializedProps.add(prop);
 				const valueResolution = context.tryResolveValue(this, prop, state);
 				if (valueResolution)
@@ -161,7 +161,7 @@ export class Entity {
 		// Set the specified properties
 		for (let [propName, state] of Entity.getSortedPropertyData(properties)) {
 			const prop = this.serializer.resolveProperty(this, propName);
-			if (prop) {
+			if (prop && !prop.isCalculated && !prop.isConstant) {
 				const valueResolution = this._context ? this._context.tryResolveValue(this, prop, state) : null;
 				if (valueResolution)
 					valueResolution.then(asyncState => this.setProp(prop, asyncState));

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -14,7 +14,17 @@ function resetModel() {
 				type: String
 			},
 			FirstName: String,
-			LastName: String
+			LastName: String,
+			FullName: {
+				type: String,
+				get() {
+					return `${this.FirstName} ${this.LastName}`;
+				}
+			},
+			Species: {
+				constant: "Homo sapiens",
+				type: String
+			}
 		},
 		Movie: {
 			Id: {
@@ -73,6 +83,16 @@ describe("Entity", () => {
 
 			expect(movie.serialize()).toEqual(Alien);
 		});
+
+		it("cannot initialize calculated properties", () => {
+			const person = new Types.Person({ FirstName: "John", LastName: "Doe", FullName: "Jane Doe" });
+			expect(person.FullName).toBe("John Doe");
+		});
+
+		it("cannot initialize constant properties", () => {
+			const person = new Types.Person({ Species: "Homo erectus" });
+			expect(person.Species).toBe("Homo sapiens");
+		});
 	});
 
 	describe("set", () => {
@@ -80,6 +100,18 @@ describe("Entity", () => {
 			const movie = new Types.Movie();
 			movie.set(Alien);
 			expect(movie.serialize()).toEqual(Alien);
+		});
+
+		it("cannot be used to set calculated properties", () => {
+			const person = new Types.Person({ FirstName: "John", LastName: "Doe" });
+			person.set({ FullName: "Full Name" });
+			expect(person.FullName).toBe("John Doe");
+		});
+
+		it("cannot be used to set constant properties", () => {
+			const person = new Types.Person();
+			person.set({ Species: "Homo erectus" });
+			expect(person.Species).toBe("Homo sapiens");
 		});
 	});
 


### PR DESCRIPTION
This addresses the issue of being able to prefill calculated properties on cognito forms.