### PR TITLE
fix bugs with asynchronous updating of entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "build:typescript": "rimraf ./@types && rimraf ./lib && tsc",
-    "build:webpack": "rimraf ./out && webpack --mode=production",
+    "build:typescript": "tsc",
+    "build:webpack": "webpack --mode=production",
     "build": "npm run build:typescript && npm run build:webpack",
     "build:watch": "nodemon -e ts --watch src/ -x \"npm run build\"",
     "test": "jest",

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -227,7 +227,7 @@ export class Entity {
 				else if (typeof state !== "object")
 					value = state;
 				else if (currentValue && !getIdFromState(ChildEntity.meta, state))
-					currentValue.updateInContext(this._context, state);
+					(currentValue as Entity).updateWithContext(this._context, state);
 				// Got an object, so attempt to fetch or create and assign the state
 				else
 					value = Type$createOrUpdate(ChildEntity.meta, state, this._context).instance;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -166,11 +166,8 @@ export class Entity {
 			const prop = this.serializer.resolveProperty(this, propName);
 			if (prop && !prop.isCalculated && !prop.isConstant) {
 				const valueResolution = this._context ? this._context.tryResolveValue(this, prop, state) : null;
-				if (valueResolution) {
-					valueResolution.then(asyncState => {
-						this.setProp(prop, asyncState);
-					});
-				}
+				if (valueResolution)
+					valueResolution.then(asyncState => this.setProp(prop, asyncState));
 				else
 					this.setProp(prop, state);
 			}

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -21,7 +21,7 @@ export class InitializationContext {
 			// allow additional tasks to be queued as a result of this one
 			Promise.resolve().then(() => {
 				if (this.tasks.size === 0)
-					while (this.waiting.length > 0) {
+					while (this.waiting.length > 0 && this.tasks.size === 0) {
 						const done = this.waiting.shift();
 						done();
 					}

--- a/src/type.ts
+++ b/src/type.ts
@@ -508,7 +508,7 @@ export function Type$createOrUpdate(type: Type, state: any, contextOrResolver: I
 	let instance = id && type.get(id);
 	if (instance) {
 		// Assign state to the existing object
-		instance.withContext(context, () => instance.set(state));
+		instance.updateWithContext(context, state);
 	}
 	else {
 		// Cast the jstype to any so we can call the internal constructor signature that takes a context

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -13,7 +13,7 @@ describe("Type", () => {
 				$extends: "Base"
 			}
 		});
-        
+
 		expect(model.types.Sub.identifier).toBe(model.types.Base.identifier);
 	});
 
@@ -42,5 +42,84 @@ describe("Type", () => {
 				return Promise.resolve({ Id: value, Name: "Sibling Name" });
 		});
 		expect(parent.Child.Sibling.Name).toBe("Sibling Name");
+	});
+
+	/**
+	 * The core issue here was that any task queued on an InitializationContext as a result of a ready() callback
+	 * would not prevent further processing of the waiting queue.
+	 */
+	test("createOrUpdate should support multilevel async resolution within list items", async () => {
+		const model = new Model({
+			Lookup: {
+				Id: { identifier: true, type: String },
+				Name: String
+			},
+			ListItem: {
+				Lookup: "Lookup"
+			},
+			Parent: {
+				Id: { identifier: true, type: String },
+				List: "ListItem[]"
+			}
+		});
+
+		const db = {
+			Lookup: {
+				"a": { Id: "a", Name: "Lookup A" },
+				"b": { Id: "B", Name: "Lookup B" }
+			}
+		};
+
+		const valueResolver = (instance, prop, value) => {
+			if (db[prop.propertyType.name])
+				return new Promise(resolve => setTimeout(() => resolve(db[prop.propertyType.name][value]), 10));
+		};
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		await model.types.Parent.create({
+			List: [
+				{ Lookup: "a" },
+				{ Lookup: "b" }
+			]
+		}, valueResolver);
+		const parent = await model.types.Parent.create({
+			List: [
+				{ Lookup: "a" },
+				{ Lookup: "b" }
+			]
+		}, valueResolver);
+		expect(parent.List[1].Lookup.Name).toBe("Lookup B");
+	});
+
+	test("createOrUpdate should support circular async resolution after entities already exist", async () => {
+		const model = new Model({
+			Entity: {
+				Id: { identifier: true, type: String },
+				Name: String,
+				Sibling: "Entity"
+			}
+		});
+
+		const entities = {
+			a: {
+				Id: "a",
+				Name: "Entity A",
+				Sibling: "b"
+			},
+			b: {
+				Id: "b",
+				Name: "Entity B",
+				Sibling: "a"
+			}
+		};
+
+		const siblingResolver = (instance, prop, value) => {
+			if (prop.name === "Sibling")
+				return new Promise(resolve => setTimeout(() => resolve(entities[value]), 10));
+		};
+
+		// ensure entity instances already exist and are pooled
+		await model.types.Entity.create(entities.a, siblingResolver);
+		let root = await model.types.Entity.create(entities.a, siblingResolver);
+		expect(root.Sibling.Sibling).toBe(root);
 	});
 });


### PR DESCRIPTION
## Specific bugs
- infinite recursion when an entity graph is circular via asynchronously resolved properties
- premature execution of waiting callbacks on the initialization context preventing async resolution of some property values

## Description of changes
- refactor `Entity.withContext` to be `Entity.updateWithContext`, making it serve the specific purpose of calling `set()` with a given `InitializationContext` (this lets us be more rigorous in the implementation, specifically allowing the reentrancy clause)
- prevent reentrant calls to `Entity.updateWithContext` for the same entity with the same context (avoids infinite recursion)
- short circuit processing of `waiting` queue on `InitializationContext` if a waiting callback queues a new task on the context
- tweak logic around updating entity lists in `Entity.setProp` to update the list item if
    + its identifier matches the identifier in the state object or
    + the entities in the list are not pooled (no identifier)