### PR TITLE
Change normalize to accept a format string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- Change the `normalize` function to accept a format string
+
 ## [0.8.0] - 2020-08-07
 ### Changed
 - provide source rule/format when creating conditions

--- a/src/model.ts
+++ b/src/model.ts
@@ -429,23 +429,26 @@ function normalizeDateTime(dateTime: Date, standard: Date): Date {
 	_dateTime.setFullYear(standard.getFullYear());
 	return _dateTime ;
 }
-	
+
 // Normalize the provided value based on the format specifier
 // so that it can be used appropriately for comparisons
-export function normalize(val: any, format: Format<any>) : any {
+export function normalize(val: Date, format: string) : Date;
+export function normalize(val: Date, format: Format<any>) : Date;
+export function normalize(val: any, format: Format<any> | string) : any {
 	if (!val && val !== false)
 		return val;
 
 	if (val.constructor.name === "Date") {
-		if (format.specifier === "t") {
+		let dateFormat = typeof format === "string" ? format : format.specifier;
+		if (dateFormat === "t") {
 			// Set the date of the dateTime to January 1st, 1970
 			val = normalizeDateTime(val, JAN_01_1970);
 		}
-		else if (format.specifier === "d") {
+		else if (dateFormat === "d") {
 			// Set the time of the dateTime to 12AM
 			val = normalizeDateTime(JAN_01_1970, val);
 		}
 	}
 
 	return val;
-};
+}

--- a/src/model.unit.js
+++ b/src/model.unit.js
@@ -1,0 +1,15 @@
+import { normalize } from "./model";
+
+describe("normalize", () => {
+	it("returns the time portion of the given date if the format is 't'", async () => {
+		const ts = new Date(1597757877175);
+		expect(ts).toEqual(new Date(2020, 7, 18, 9, 37, 57, 175));
+		expect(normalize(ts, "t")).toEqual(new Date(1970, 0, 1, 9, 37, 57, 175));
+	});
+
+	it("returns the day portion of the given date if the format is 'd'", async () => {
+		const ts = new Date(1597757877175);
+		expect(ts).toEqual(new Date(2020, 7, 18, 9, 37, 57, 175));
+		expect(normalize(ts, "d")).toEqual(new Date(2020, 7, 18));
+	});
+});


### PR DESCRIPTION
The method was checking for constants "d" and "t" anyway, so its functionally equivalent to just take the string arg directly. This probably should be an instance method on the model, since formats depend on localization, but since it doesn't make a difference in the way its used I propose this simple change for now.