### PR TITLE
fix timing issue with circular calculation and stackoverflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Fixed
+- incorrect initialization of calculations due to timing issues during entity construction
+- stack overflow when initializing calculated list properties
 ### Changed
 - Change the `normalize` function to accept a format string
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -143,7 +143,7 @@ export class Entity {
 			this._context = context;
 		// Ensure provided context waits on the existing context to be ready
 		else if (this._context !== context)
-			context.wait(this._context.readyPromise);
+			context.wait(this._context.ready);
 
 		this.set(state);
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -59,9 +59,7 @@ export class Entity {
 			// Initialize existing entity with provided property values
 			if (!isNew && properties) {
 				// We need to pause processing of callbacks to prevent publishing entity events while still processing the state graph
-				const resumeContextQueue = context.delayQueue();
-				this.init(properties, context);
-				resumeContextQueue();
+				context.execute(() => this.init(properties, context));
 			}
 
 			// Raise the initNew or initExisting event on this type and all base types

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -65,7 +65,7 @@ export class InitializationContext {
 		return this.newDocument;
 	}
 
-	get readyPromise() {
+	get ready() {
 		return new Promise(resolve => this.whenReady(resolve));
 	}
 }

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -15,14 +15,20 @@ export class InitializationContext {
 	}
 
 	/**
-	 * Prevents any waiting callbacks from being executed.
-	 * @returns A callback which removes your delay.
+	 * Prevents any waiting callbacks from being executed before the specified action completes.
+	 * @returns The return value of `action`.
 	 */
-	delayQueue() {
+	execute<T>(action: () => T): T {
 		// create a promise which will never actually be resolved, but it will prevent the waiting queue from being processed
 		const marker = new Promise(() => {});
 		this.tasks.add(marker);
-		return () => this.tasks.delete(marker) && this.processWaitingQueue();
+
+		const result = action();
+
+		this.tasks.delete(marker);
+		this.processWaitingQueue();
+
+		return result;
 	}
 
 	wait(task: Promise<any>) {

--- a/src/type.ts
+++ b/src/type.ts
@@ -507,22 +507,21 @@ export function Type$createOrUpdate(type: Type, state: any, contextOrResolver: I
 
 	// We need to pause processing of callbacks to prevent publishing entity events while still processing
 	// the state graph
-	const resumeContextQueue = context.delayQueue();
-
-	let instance = id && type.get(id);
-	if (instance) {
-		// Assign state to the existing object
-		instance.updateWithContext(context, state);
-	}
-	else {
-		// Cast the jstype to any so we can call the internal constructor signature that takes a context
-		// We don't want to put the context on the public constructor interface
-		const Ctor = type.jstype as any;
-		// Construct an instance using the known id if it is present
-		instance = (id ? new Ctor(id, state, context) : new Ctor(state, context)) as Entity;
-	}
-
-	resumeContextQueue();
+	const instance = context.execute(() => {
+		let instance = id && type.get(id);
+		if (instance) {
+			// Assign state to the existing object
+			instance.updateWithContext(context, state);
+		}
+		else {
+			// Cast the jstype to any so we can call the internal constructor signature that takes a context
+			// We don't want to put the context on the public constructor interface
+			const Ctor = type.jstype as any;
+			// Construct an instance using the known id if it is present
+			instance = (id ? new Ctor(id, state, context) : new Ctor(state, context)) as Entity;
+		}
+		return instance;
+	});
 
 	return { context, instance };
 }


### PR DESCRIPTION
This bug demonstrates the calculation issue: https://dev.azure.com/cognitoforms/Cognito%20Forms/_workitems/edit/16916

Setup
---
A form with
- a repeating section **RS**
  - with a number field **Num**
- a section **S**
  - with a calculation **C** based on the sum of **Form.RS.Num** <-- the circular nature of `Form` seems to be key here
    - and a custom error that references **C**

Behavior
---
When initializing an existing entry that contains multiple items in **RS**, **C** is not initialized correctly because it seems the custom error triggers initialization of **C** _before_ **RS** has been deserialized/populated. In short, **S** is "fully initialized" before we have even processed/initialized the state of **RS**.

Fix
---
I've added a synchronous blocking mechanism to the `InitializationContext` which prevents any part of the object graph from "fully initializing" (init events, etc.) until the rest of the state graph has been processed.

Other changes
---
- fixed a bug with calculated list properties which causes stack overflow

Testing
---
- added a test to cover the calculated list property stackoverflow
- I couldn't create a negative test case manually, but I've added a test to cover this issue in the product codebase
