### PR TITLE
return null when calling formatNumber with null

### DIFF
--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -940,7 +940,7 @@ function expandNumber(number: number, precision: number, groupSizes: number[], s
  * @param cultureInfo The culture
  */
 export function formatNumber(number: number, format: string, cultureInfo: CultureInfo): string {
-	if (isNaN(number))
+	if (number === null || isNaN(number))
 		return null;
 
 	if (!format || (format.length === 0) || (format === "i")) {

--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -940,7 +940,7 @@ function expandNumber(number: number, precision: number, groupSizes: number[], s
  * @param cultureInfo The culture
  */
 export function formatNumber(number: number, format: string, cultureInfo: CultureInfo): string {
-	if (number === null || isNaN(number))
+	if (typeof number !== "number" || isNaN(number))
 		return null;
 
 	if (!format || (format.length === 0) || (format === "i")) {

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -58,6 +58,10 @@ describe("globalize", function () {
 		test("formatNumber-n1", () => {
 			expect(formatNumber(3.14, "n1", CultureInfo.CurrentCulture)).toBe("3.1");
 		});
+
+		test("returns null given null", () => {
+			expect(formatNumber(null, "n1", CultureInfo.CurrentCulture)).toBeNull();
+		});
 	});
 
 	describe("parseNumber", () => {

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -62,6 +62,14 @@ describe("globalize", function () {
 		test("returns null given null", () => {
 			expect(formatNumber(null, "n1", CultureInfo.CurrentCulture)).toBeNull();
 		});
+
+		test("returns null given string", () => {
+			expect(formatNumber("5", "n1", CultureInfo.CurrentCulture)).toBeNull();
+		});
+
+		test("returns null given object", () => {
+			expect(formatNumber({ x: 5 }, "n1", CultureInfo.CurrentCulture)).toBeNull();
+		});
 	});
 
 	describe("parseNumber", () => {


### PR DESCRIPTION
Currently, `null` will be formatted as if it were `0`. There was a `isNaN()` check added to `formatNumber()` but `null` is considered to be a number. My guess is it was assumed `null` would be `NaN`.