### PR TITLE
Event scope revisited - bug fixes and module refactor

### DIFF
--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -45,23 +45,16 @@ export class EventScope {
 			// Invoke the callback
 			callback();
 			isDisposing = true;
-			scope.dispose({ abort: false });
+			this.current.dispose({ abort: false });
 		}
 		catch (e) {
-			if (!isDisposing) {
-				// Exit the event scope
-				scope.dispose({ abort: true });
-			}
+			if (!isDisposing)
+				this.current.dispose({ abort: true });
 		}
 		finally {
-			if (scope !== this.current) {
-				console.warn(`Exited non-current event scope ${scope._uid}.`);
-			}
-			else {
-				// Roll back to the closest active scope
-				while (this.current && !this.current.isActive) {
-					this.current = this.current.parent;
-				}
+			// Roll back to the closest active scope
+			while (this.current && !this.current.isActive) {
+				this.current = this.current.parent;
 			}
 		}
 	}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -148,7 +148,7 @@ export class EventScope {
 					else {
 						try {
 							// Attempt to move subscribers to the parent scope
-							this.parent.receiveEventHandlers(exitSubscriptions);
+							this.parent.receiveExitEventSubscribers(exitSubscriptions);
 						}
 						catch (e) {
 							this.dispose({ abort: true });
@@ -167,18 +167,14 @@ export class EventScope {
 		}
 	}
 
-	private receiveEventHandlers(subscriptions: EventSubscription<EventScope, EventScopeExitEventArgs>[]) {
+	private receiveExitEventSubscribers(subscriptions: EventSubscription<EventScope, EventScopeExitEventArgs>[]) {
 		var maxNesting = this.settings.maxExitingTransferCount - 1;
 		if (this._exitEventVersion >= maxNesting) {
 			throw new Error("Exceeded max scope event transfer.");
 		}
 
 		// Move subscribers to the parent scope
-		subscriptions.forEach(sub => {
-			if (!sub.isOnce || !sub.isExecuted) {
-				this._onExit.subscribe(sub.handler);
-			}
-		});
+		subscriptions.forEach(sub => this._onExit.subscribe(sub.handler));
 
 		if (this._exitEventVersion !== undefined) {
 			this._exitEventVersion++;

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -134,47 +134,37 @@ export class EventScope {
 	}
 }
 
-export function EventScope$onExit(callback: Function, thisPtr: any = null): void {
+export function EventScope$onExit(callback: Function): void {
 	if (EventScope$current === null) {
 		// Immediately invoke the callback
-		if (thisPtr) {
-			callback.call(thisPtr);
-		}
-		else {
-			callback();
-		}
+		callback();
 	}
 	else if (!EventScope$current.isActive) {
 		throw new Error("The current event scope cannot be inactive.");
 	}
 	else {
 		// Subscribe to the exit event
-		EventScope$current.onExit.subscribe(callback.bind(thisPtr));
+		EventScope$current.onExit.subscribe(callback as any);
 	}
 }
 
-export function EventScope$onAbort(callback: Function, thisPtr: any = null): void {
+export function EventScope$onAbort(callback: Function): void {
 	if (EventScope$current !== null) {
 		if (!EventScope$current.isActive) {
 			throw new Error("The current event scope cannot be inactive.");
 		}
 
 		// Subscribe to the abort event
-		EventScope$current.onAbort.subscribe(callback.bind(thisPtr));
+		EventScope$current.onAbort.subscribe(callback as any);
 	}
 }
 
-export function EventScope$perform(callback: Function, thisPtr: any = null): void {
+export function EventScope$perform(callback: Function): void {
 	// Create an event scope
 	var scope = new EventScope();
 	try {
 		// Invoke the callback
-		if (thisPtr) {
-			callback.call(thisPtr);
-		}
-		else {
-			callback();
-		}
+		callback();
 	}
 	finally {
 		// Exit the event scope

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -60,6 +60,7 @@ export class EventScope {
 			if (!isDisposing)
 				this.current.dispose({ abort: true });
 
+			console.warn(`Error occurred in EventScope ${(isDisposing ? "dispose" : "callback")} function.`);
 			throw e;
 		}
 		finally {
@@ -118,6 +119,7 @@ export class EventScope {
 						}
 						catch (e) {
 							this.dispose({ abort: true });
+							console.warn("Error occurred in EventScope dispose function.");
 							throw e;
 						}
 					}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -24,7 +24,6 @@ export class EventScope {
 
 	readonly _onExit: EventSubscriber<EventScope, EventScopeExitEventArgs>;
 	private _exitEventVersion: number;
-	private _exitEventHandlerCount: number;
 
 	private constructor(parent: EventScope, isActive: boolean = false) {
 		this.parent = parent;
@@ -96,15 +95,13 @@ export class EventScope {
 				if (exitSubscriptions && exitSubscriptions.length > 0) {
 					// If there is no parent scope, then go ahead and execute the 'exit' event
 					if (this.parent === null || !this.parent.isActive) {
-						// Record the initial version and initial number of subscribers
+						// Record the initial "version" before starting to call subscribers
 						this._exitEventVersion = 0;
-						this._exitEventHandlerCount = exitSubscriptions.length;
 
 						// Invoke all subscribers
 						(this._onExit as Event<EventScope, EventScopeExitEventArgs>).publish(this, { abort: false });
 
-						// Delete the fields to indicate that raising the exit event suceeded
-						delete this._exitEventHandlerCount;
+						// Delete the field to indicate that raising the exit event suceeded
 						delete this._exitEventVersion;
 					}
 					else {

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -5,12 +5,11 @@ export let EventScope$current: EventScope = null;
 
 let __lastEventScopeId = 0;
 
-// TODO: Make `nonExitingScopeNestingCount` an editable configuration value
 // Controls the maximum number of times that a child event scope can transfer events
 // to its parent while the parent scope is exiting. A large number indicates that
 // rules are not reaching steady-state. Technically something other than rules could
 // cause this scenario, but in practice they are the primary use-case for event scope.
-const nonExitingScopeNestingCount = 100;
+export const EventScope$nonExitingScopeNestingCount = 100;
 
 interface EventScopeExitEventArgs {
 }
@@ -88,8 +87,7 @@ export class EventScope {
 					delete this._exitEventVersion;
 				}
 				else {
-					// if (typeof ...config.nonExitingScopeNestingCount === "number") { ...
-					var maxNesting = nonExitingScopeNestingCount - 1;
+					var maxNesting = EventScope$nonExitingScopeNestingCount - 1;
 					if (this.parent._exitEventVersion >= maxNesting) {
 						this.abort(true);
 						console.warn(`[event-scope] Exceeded max nesting of ${maxNesting}`);

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -60,7 +60,6 @@ export class EventScope {
 			if (!isDisposing)
 				this.current.dispose({ abort: true });
 
-			console.warn(`Error occurred in EventScope ${(isDisposing ? "dispose" : "callback")} function.`);
 			throw e;
 		}
 		finally {
@@ -119,7 +118,6 @@ export class EventScope {
 						}
 						catch (e) {
 							this.dispose({ abort: true });
-							console.warn("Error occurred in EventScope dispose function.");
 							throw e;
 						}
 					}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -90,7 +90,7 @@ export class EventScope {
 					var maxNesting = EventScope$nonExitingScopeNestingCount - 1;
 					if (this.parent._exitEventVersion >= maxNesting) {
 						this.abort(true);
-						console.warn(`[event-scope] Exceeded max nesting of ${maxNesting}`);
+						console.warn("Exceeded max scope nesting.");
 						scopeAborted = true;
 						return;
 					}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -3,6 +3,8 @@ import { getEventSubscriptions } from "./helpers";
 
 export let EventScope$current: EventScope = null;
 
+let __lastEventScopeId = 0;
+
 // TODO: Make `nonExitingScopeNestingCount` an editable configuration value
 // Controls the maximum number of times that a child event scope can transfer events
 // to its parent while the parent scope is exiting. A large number indicates that
@@ -22,6 +24,8 @@ export class EventScope {
 
 	isActive: boolean;
 
+	readonly _uid: number;
+
 	private _exitEventVersion: number;
 	private _exitEventHandlerCount: number;
 
@@ -29,6 +33,8 @@ export class EventScope {
 	readonly onAbort: EventSubscriber<EventScope, EventScopeAbortEventArgs>;
 
 	constructor() {
+		this._uid = ++__lastEventScopeId;
+
 		// If there is a current event scope
 		// then it will be the parent of the new event scope
 		this.parent = EventScope$current;

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -40,18 +40,18 @@ export class EventScope {
 	perform(callback: Function): void {
 		// Create an event scope
 		var scope = new EventScope(this.current, true);
-		let isExiting = false;
+		let isDisposing = false;
 		try {
 			this.current = scope;
 			// Invoke the callback
 			callback();
-			isExiting = true;
-			scope.exit({ abort: false });
+			isDisposing = true;
+			scope.dispose({ abort: false });
 		}
 		catch (e) {
-			if (!isExiting) {
+			if (!isDisposing) {
 				// Exit the event scope
-				scope.exit({ abort: true });
+				scope.dispose({ abort: true });
 			}
 		}
 		finally {
@@ -81,7 +81,7 @@ export class EventScope {
 		}
 	}
 
-	exit({ abort = false }: EventScopeExitEventArgs): void {
+	dispose({ abort = false }: EventScopeExitEventArgs): void {
 		if (!this.isActive) {
 			throw new Error("The event scope cannot be exited because it is not active.");
 		}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -112,7 +112,7 @@ export class EventScope {
 					else {
 						var maxNesting = EventScope$nonExitingScopeNestingCount - 1;
 						if (this.parent._exitEventVersion >= maxNesting) {
-							this.exit({ abort: true });
+							this.dispose({ abort: true });
 							console.warn("Exceeded max scope nesting.");
 							return;
 						}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -149,4 +149,8 @@ export class EventScope {
 			this._exitEventVersion++;
 		}
 	}
+
+	toString() {
+		return `${(this.parent ? this.parent.toString() + "->" : "")}${this._uid}`;
+	}
 }

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -36,14 +36,23 @@ export class EventScope {
 		return new EventScope(null, false);
 	}
 
+	/**
+	 * Creates a new event scope, performs the action, then exits the scope
+	 * @param callback The action to perform within the new scope
+	 */
 	perform(callback: Function): void {
 		// Create an event scope
 		var scope = new EventScope(this.current, true);
+
 		let isDisposing = false;
+
 		try {
 			this.current = scope;
+
 			// Invoke the callback
 			callback();
+
+			// Dispose of the event scope
 			isDisposing = true;
 			this.current.dispose({ abort: false });
 		}
@@ -59,6 +68,10 @@ export class EventScope {
 		}
 	}
 
+	/**
+	 * Subscribes to the "exit" event of the current scope, or invokes immediately if there is not a current scope
+	 * @param handler The event handler to invoke when exited
+	 */
 	onExit(handler: (args: EventScopeExitEventArgs) => void): void {
 		if (this.current === null) {
 			// Immediately invoke the callback

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -17,12 +17,11 @@ export class EventScope {
 	readonly parent: EventScope;
 
 	current: EventScope = null;
-
 	isActive: boolean;
 
-	readonly _uid: number;
+	private readonly _uid: number;
 
-	readonly _onExit: EventSubscriber<EventScope, EventScopeExitEventArgs>;
+	private readonly _onExit: EventSubscriber<EventScope, EventScopeExitEventArgs>;
 	private _exitEventVersion: number;
 
 	private constructor(parent: EventScope, isActive: boolean = false) {
@@ -81,7 +80,7 @@ export class EventScope {
 		}
 	}
 
-	dispose({ abort = false }: EventScopeExitEventArgs): void {
+	private dispose({ abort = false }: EventScopeExitEventArgs): void {
 		if (!this.isActive) {
 			throw new Error("The event scope cannot be exited because it is not active.");
 		}

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -59,6 +59,8 @@ export class EventScope {
 		catch (e) {
 			if (!isDisposing)
 				this.current.dispose({ abort: true });
+
+			throw e;
 		}
 		finally {
 			// Roll back to the closest active scope
@@ -116,15 +118,14 @@ export class EventScope {
 						}
 						catch (e) {
 							this.dispose({ abort: true });
-							console.warn(e);
-							return;
+							throw e;
 						}
 					}
 				}
-
-				// Clear the events to ensure that they aren't inadvertantly raised again through this scope
-				this._onExit.clear();
 			}
+
+			// Clear the events to ensure that they aren't inadvertantly raised again through this scope
+			this._onExit.clear();
 		}
 		finally {
 			// The event scope is no longer active

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -1,0 +1,136 @@
+import { EventScope$current, EventScope$perform, EventScope$onExit, EventScope$nonExitingScopeNestingCount } from "./event-scope";
+import "./resource-en";
+import { CultureInfo } from "./globalization";
+import { Model } from "./model";
+
+describe("EventScope", () => {
+	it("creates a new scope when 'perform' is called", () => {
+		let counter = 0;
+		expect(EventScope$current).toBeNull();
+		EventScope$perform(() => {
+			expect(EventScope$current).not.toBeNull();
+		    counter++;
+		});
+		expect(counter).toBe(1);
+		expect(EventScope$current).toBeNull();
+	});
+	it("invokes the callback immediately if a scope was not already active", () => {
+		let counter = 0;
+		EventScope$perform(() => {
+			expect(counter).toBe(0);
+		    counter++;
+		});
+		expect(counter).toBe(1);
+		counter++;
+	});
+	it("invokes 'onExit' when the active scope exits", () => {
+		let counter = 0;
+		EventScope$perform(() => {
+			expect(counter).toBe(0);
+			counter++;
+			EventScope$onExit(() => {
+				expect(counter).toBe(1);
+			});
+		});
+		expect(counter).toBe(1);
+		counter++;
+	});
+	it("exits automatically when an error occurs", () => {
+		let counter = 0;
+		expect(EventScope$current).toBeNull();
+		EventScope$perform(() => {
+			counter++;
+			throw new Error("Fail!");
+		});
+		expect(counter).toBe(1);
+		expect(EventScope$current).toBeNull();
+	});
+	it("aborts when the maximum scope nesting count is reached", () => {
+		CultureInfo.setup();
+		const model = new Model({
+			$namespace: {},
+			$locale: "en",
+			"Context": {
+				"SearchText": {
+					type: String,
+					default: {
+						dependsOn: "MatchedUser{IsArchived,FullName,Id}",
+						function(this: any) {
+							if (this.MatchedUser) {
+								if (this.MatchedUser.IsArchived) {
+									return this.MatchedUser.toString("[FullName]");
+								}
+								else {
+									return this.MatchedUser.toString("[Id]");
+								}
+							}
+						}
+					}
+				},
+				"MatchedUser": {
+					type: "UserRef",
+					get: {
+						dependsOn: "SearchText",
+						function(this: any) {
+							if (this.SearchText) {
+								const usersById = this.Users.filter(u => u.Id === this.SearchText);
+								if (usersById.length) {
+									return usersById[0];
+								}
+
+								const usersByName = this.Users.filter(u => !u.IsArchived && u.FullName.indexOf(this.SearchText) >= 0);
+								if (usersByName.length) {
+									return usersByName[0];
+								}
+							}
+						}
+					},
+					set(this: any) {
+						if (this.MatchedUser) {
+							this.MatchedUser.FirstName += "*";
+							if (this.MatchedUser.IsArchived) {
+								this.SearchText = this.MatchedUser.toString("[FullName]");
+							}
+							else {
+								this.SearchText = this.MatchedUser.toString("[Id]");
+							}
+						}
+					}
+				},
+				"Users": {
+					type: "UserRef[]"
+				}
+			},
+			"UserRef": {
+				$format: "[FullName]",
+				"Id": String,
+				"IsArchived": Boolean,
+				"FirstName": String,
+				"LastName": String,
+				"FullName": {
+					type: "String",
+					get: {
+						dependsOn: "{FirstName,LastName}",
+						function() {
+							return this.toString("[FirstName] [LastName]");
+						}
+					}
+				}
+			}
+		});
+
+		const context = new model.$namespace.Context();
+		const user1 = new model.$namespace.UserRef({ FirstName: "Dave", LastName: "Smith", Id: "abc123", IsArchived: true });
+		context.Users.push(user1);
+		const user2 = new model.$namespace.UserRef({ FirstName: "Bob", LastName: "Smith", Id: "abc123", IsArchived: false });
+		context.Users.push(user2);
+		context.SearchText = "abc123";
+		expect(context.MatchedUser).not.toBeNull();
+		expect(context.MatchedUser.FullName).toBe("Dave Smith");
+		context.MatchedUser.FirstName = "Bob";
+		const maxNesting = EventScope$nonExitingScopeNestingCount - 1;
+		const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
+		expect(context.SearchText).toBe("Bob" + Array.from(new Array(expectedCalculationCount)).map(() => "*").join("") + " Smith");
+		expect(EventScope$current).toBeNull();
+	});
+});

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -26,7 +26,7 @@ describe("EventScope", () => {
 		expect(counter).toBe(1);
 		counter++;
 	});
-	it("invokes 'onComplete' when the active scope exits", () => {
+	it("invokes 'onExit' when the active scope exits", () => {
 		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		scope.perform(() => {

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -1,4 +1,4 @@
-import { EventScope } from "./event-scope";
+import { EventScope, EventScope$nonExitingScopeNestingCount } from "./event-scope";
 import "./resource-en";
 import { CultureInfo } from "./globalization";
 import { Model } from "./model";
@@ -137,7 +137,7 @@ describe("EventScope", () => {
 		expect(context.MatchedUser).not.toBeNull();
 		expect(context.MatchedUser.FullName).toBe("Dave Smith");
 		context.MatchedUser.FirstName = "Bob";
-		const maxNesting = 100 - 1;
+		const maxNesting = EventScope$nonExitingScopeNestingCount - 1;
 		const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
 		expect(context.SearchText).toBe("Bob" + Array.from(new Array(expectedCalculationCount)).map(() => "*").join("") + " Smith");
 		expect(model.eventScope.current).toBeNull();

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -1,4 +1,4 @@
-import { EventScope, EventScope$nonExitingScopeNestingCount } from "./event-scope";
+import { EventScope, EVENT_SCOPE_DEFAULT_SETTINGS } from "./event-scope";
 import "./resource-en";
 import { CultureInfo } from "./globalization";
 import { Model } from "./model";
@@ -6,7 +6,7 @@ import { Model } from "./model";
 describe("EventScope", () => {
 	beforeAll(() => CultureInfo.setup());
 	it("creates a new scope when 'perform' is called", () => {
-		const scope = EventScope.create();
+		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		expect(scope.current).toBeNull();
 		scope.perform(() => {
@@ -17,7 +17,7 @@ describe("EventScope", () => {
 		expect(scope.current).toBeNull();
 	});
 	it("invokes the callback immediately if a scope was not already active", () => {
-		const scope = EventScope.create();
+		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		scope.perform(() => {
 			expect(counter).toBe(0);
@@ -27,7 +27,7 @@ describe("EventScope", () => {
 		counter++;
 	});
 	it("invokes 'onComplete' when the active scope exits", () => {
-		const scope = EventScope.create();
+		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		scope.perform(() => {
 			expect(counter).toBe(0);
@@ -40,7 +40,7 @@ describe("EventScope", () => {
 		counter++;
 	});
 	it("exits automatically when an error occurs", () => {
-		const scope = EventScope.create();
+		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		expect(scope.current).toBeNull();
 		try {
@@ -137,7 +137,7 @@ describe("EventScope", () => {
 		expect(context.MatchedUser).not.toBeNull();
 		expect(context.MatchedUser.FullName).toBe("Dave Smith");
 		context.MatchedUser.FirstName = "Bob";
-		const maxNesting = EventScope$nonExitingScopeNestingCount - 1;
+		const maxNesting = model.eventScope.settings.maxExitingTransferCount - 1;
 		const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
 		expect(context.SearchText).toBe("Bob" + Array.from(new Array(expectedCalculationCount)).map(() => "*").join("") + " Smith");
 		expect(model.eventScope.current).toBeNull();
@@ -180,6 +180,8 @@ describe("EventScope", () => {
 					}
 				}
 			}
+		}, {
+			maxEventScopeDepth: 100
 		});
 
 		const user1 = new model.$namespace.User({ FirstName: "Dave", LastName: "Smith" });

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -4,6 +4,7 @@ import { CultureInfo } from "./globalization";
 import { Model } from "./model";
 
 describe("EventScope", () => {
+	beforeAll(() => CultureInfo.setup());
 	it("creates a new scope when 'perform' is called", () => {
 		const scope = EventScope.create();
 		let counter = 0;
@@ -55,7 +56,6 @@ describe("EventScope", () => {
 		expect(scope.current).toBeNull();
 	});
 	it("aborts when the maximum scope nesting count is reached", () => {
-		CultureInfo.setup();
 		const model = new Model({
 			$namespace: {},
 			$locale: "en",

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -28,14 +28,12 @@ describe("EventScope", () => {
 		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		scope.perform(() => {
-			expect(counter).toBe(0);
 			counter++;
 			scope.onExit(() => {
-				expect(counter).toBe(1);
+				counter++;
 			});
 		});
-		expect(counter).toBe(1);
-		counter++;
+		expect(counter).toBe(2);
 	});
 	it("exits automatically when an error occurs", () => {
 		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -20,11 +20,9 @@ describe("EventScope", () => {
 		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);
 		let counter = 0;
 		scope.perform(() => {
-			expect(counter).toBe(0);
 		    counter++;
 		});
 		expect(counter).toBe(1);
-		counter++;
 	});
 	it("invokes 'onExit' when the active scope exits", () => {
 		const scope = EventScope.create(EVENT_SCOPE_DEFAULT_SETTINGS);

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,10 +1,14 @@
 import { Functor$create, FunctorWith1Arg, FunctorItem } from "./functor";
 import { hasOwnProperty } from "./helpers";
 
-export class EventObject {
-	stopPropagation(): void {
-		// TODO: Implement 'stopPropagation()'?
-		throw new Error("Method 'stopPropagation' is not implemented.");
+export interface EventObject {
+	preventDefault(): void;
+}
+
+export class EventObjectImpl implements EventObject {
+	isDefaultPrevented: boolean = false;
+	preventDefault(): void {
+		this.isDefaultPrevented = true;
 	}
 }
 
@@ -35,7 +39,7 @@ export interface EventSubscriptionChanged<EventType> {
 }
 
 function createEventObject<EventArgsType>(args: EventArgsType): EventObject & EventArgsType {
-	let eventObject = new EventObject();
+	let eventObject: EventObject = new EventObjectImpl();
 
 	for (var prop in args) {
 		if (hasOwnProperty(args, prop)) {
@@ -56,13 +60,14 @@ export class Event<This, EventArgsType> implements EventPublisher<This, EventArg
     	}
     }
 
-    publish(thisObject: This, args: EventArgsType): void {
+    publish(thisObject: This, args: EventArgsType): EventObject & EventArgsType {
     	if (!this.func) {
     		// No subscribers
     		return;
     	}
     	let eventObject = createEventObject<EventArgsType>(args);
     	this.func.call(thisObject, eventObject);
+    	return eventObject;
     }
 
     subscribe(handler: EventHandler<This, EventArgsType>): void {

--- a/src/model.ts
+++ b/src/model.ts
@@ -6,6 +6,7 @@ import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
 import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource, resourceExists } from "./resource";
 import { CultureInfo, formatNumber, parseNumber, formatDate, parseDate, expandDateFormat, getNumberStyle } from "./globalization";
+import { EventScope } from "./event-scope";
 
 const valueTypes: { [name: string]: ValueType } = { string: String, number: Number, date: Date, boolean: Boolean };
 
@@ -20,6 +21,7 @@ export class Model {
 	readonly $culture: CultureInfo;
 
 	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs>;
+	readonly eventScope: EventScope;
 
 	private _readyCallbacks: (() => void)[];
 	private _readyProcessing = false;
@@ -31,6 +33,7 @@ export class Model {
 		this.types = {};
 		this.settings = new ModelSettings(config);
 		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs>();
+		this.eventScope = EventScope.create();
 
 		Object.defineProperty(this, "_formats", { enumerable: false, configurable: false, writable: true, value: {} });
 

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -187,12 +187,10 @@ export class Rule {
 					function (args) {
 						if (canExecuteRule(rule, args.entity) && !pendingInvocation(args.entity.meta, rule)) {
 							pendingInvocation(args.entity.meta, rule, true);
-							rule.eventScope.onExit(() => {
+							rule.eventScope.onExit(e => {
 								pendingInvocation(args.entity.meta, rule, false);
-								executeRule(rule, args.entity);
-							});
-							rule.eventScope.onAbort(() => {
-								pendingInvocation(args.entity.meta, rule, false);
+								if (!e.abort)
+									executeRule(rule, args.entity);
 							});
 						}
 					}
@@ -223,12 +221,10 @@ export class Rule {
 							// Immediately execute the rule if there are explicit event subscriptions for the property
 							if (canExecuteRule(rule, args.entity) && !pendingInvocation(args.entity.meta, rule)) {
 								pendingInvocation(args.entity.meta, rule, true);
-								rule.eventScope.onExit(() => {
+								rule.eventScope.onExit(e => {
 									pendingInvocation(args.entity.meta, rule, false);
-									executeRule(rule, args.entity);
-								});
-								rule.eventScope.onAbort(() => {
-									pendingInvocation(args.entity.meta, rule, false);
+									if (!e.abort)
+										executeRule(rule, args.entity);
 								});
 							}
 						}
@@ -238,10 +234,12 @@ export class Rule {
 								Property$pendingInit(args.entity, returnValue, true);
 							});
 							// Defer change notification until the scope of work has completed
-							rule.eventScope.onExit(() => {
-								rule.returnValues.forEach((returnValue) => {
-									(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
-								});
+							rule.eventScope.onExit(e => {
+								if (!e.abort) {
+									rule.returnValues.forEach((returnValue) => {
+										(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
+									});
+								}
 							});
 						}
 					}

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -326,7 +326,7 @@ function executeRule(rule: Rule, obj: Entity): void {
 					}
 
 					if (parentEventScope._exitEventVersion >= maxNesting) {
-						console.warn(`[rule] Exceeded max scope nesting while running rule '${rule.name}'`);
+						console.warn(`Exceeded max scope nesting while running rule '${rule.name}'.`);
 						return;
 					}
 				}

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -320,7 +320,7 @@ function executeRule(rule: Rule, obj: Entity): void {
 		});
 	}
 	catch (e) {
-		console.warn(`Error encountered while running rule "${rule.name}": ${e.message || e}`);
+		console.warn(`Error encountered while running rule "${rule.name}".`);
 	}
 };
 

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -185,11 +185,11 @@ export class Rule {
 					function (args) {
 						if (canExecuteRule(rule, args.entity) && !pendingInvocation(args.entity.meta, rule)) {
 							pendingInvocation(args.entity.meta, rule, true);
-							EventScope$onExit(function () {
+							EventScope$onExit(() => {
 								pendingInvocation(args.entity.meta, rule, false);
 								executeRule(rule, args.entity);
 							});
-							EventScope$onAbort(function () {
+							EventScope$onAbort(() => {
 								pendingInvocation(args.entity.meta, rule, false);
 							});
 						}


### PR DESCRIPTION
**Problem:**
A lurking bug in the rules framework made it possible for a bad rules configuration to cause the rules engine to stop working, with no indication that a problem had occurred (i.e. no errors in the browser console).

**Solution:**
Fix the bug by making several changes to ensure that event scopes are always able to be disposed if an error occurs. When this happens some rules may have failed to run, leaving the model in a bad or unknown state, but at least rules can continue to run in the future and so the problems could be potentially be recovered from. Also, capture errors during rule execution and log a warning to the console to aid in troubleshooting. There are also changes to runaway rule detection, and other various changes including refactoring and testing changes, detailed below...

---

Rules can be configured in such a way that they never reach "steady state", essentially creating something akin to an infinite loop or infinite recursion. When this happens, the browser will eventually trigger an error at some point, and that behavior will vary from browser to browser, determined by factors such as call stack depth, number of statements, or even time elapsed. There was a lurking bug which resulted in the rules framework not being able to recover from an unexpected error if the script was terminated in a particular location (i.e. the EventScope constructor). All of this, combined with the error trapping behavior in `CalculatedPropertyRule` would result in a situation where rules would inexplicably stop working, which no other indication that a problem had occurred (i.e. no errors in the console).

**Summary of Changes:**
- **Moved the assignment of the "current" event scope into a try/catch**, to ensure that it is disposed of if an error occurs. This avoids the problem where the current event scope would never exit if an error was thrown from within the event scope constructor. This would have never been caught by a review, since the code in the constructor was pretty benign, so an error could only occur due to something unusual, like the browser terminating the script.
- **When disposing of event scopes after performing an action, always use the current scope**, to further ensure that all scopes are disposed. Logically, when an event scope's "perform" action is complete, any child scopes should have exited, so using the local event scope doesn't provide any logical benefit and only opens up the possibility of leaving the event scope in a corrupt state.
- **Wrap rule execution in a try/catch and log errors with `console.warn`**, including the rule name. This should help bring to light any errors that may have caused rule execution to halt unexpectedly, and hopefully point the user (or developer) in the direction of the rule that caused the problem.
- **Added event scope depth detection and optional limit**, since not all problems were covered by the "non-exiting event scopes" detection that was already in place. Depending on what rules are involved in a bad rules configuration, they may get "re-queued" repeatedly, or they may infinitely nest event scopes. The former was already detected, but the latter was not prior to these changes, and so rules would run indefinitely until whatever point that the browser chose to terminate the script.
- **Significant refactor of the event scope module, including converting to a class** (previously was a singleton pattern that used module state), as well as additional clean-up. The conversation of event scope to a class allows for it to be constructed per-model, which ensures model-level isolation. In practice since the browser is single threaded only one model can be running rules at a time (aside from the possibility of custom code explicitly running rules across models), but this makes the API consistent (pretty much everything else is model-scoped). Also, if an event scope were to be corrupted at least it wouldn't affect other models.
- **Added unit tests for the event scope module**. Previously there were not any explict tests of event scope. Now, there are some tests of basic use-cases, as well as the two known variations of "runaway rules" and the corresponding detection.
- **Added per-model configurability of "runaway rule" detection limits**. Previously these were hard-coded in the module. Now they can be specified when constructing a new model. See `ModelConfiguration`, which is the optional 2nd argument to the `Model` constructor.
- **Combined "abort" and "exit" events**, since they serve the same purpose and one of them will be called in all cases.
- **Implemented "preventDefault" for events**, and removed the unimplemented `stopPropagation` method. This was done so that the error event could be cancelled to avoid cluttering the console with error messages during unit test execution.