### PR TITLE
Improve lookup form performance on page load

### DIFF
--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -88,16 +88,27 @@ export class PropertyChain implements PropertyPath {
 					let handler: PropertyChangeEventHandler;
 					let priorProp: Property = index > 0 ? props[index - 1] : null;
 					handler = args => {
-						this.rootType.known().forEach(known => {
-							if (this.testConnection(known, args.entity, priorProp)) {
-								(this.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(known, {
-									entity: known,
-									property: args.property,
-									oldValue: args.oldValue,
-									newValue: args.newValue
-								});
-							}
-						});
+						if(priorProp) {
+							this.rootType.known().forEach(known => {
+								if (this.testConnection(known, args.entity, priorProp)) {
+									(this.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(known, {
+										entity: known,
+										property: args.property,
+										oldValue: args.oldValue,
+										newValue: args.newValue
+									});
+								}
+							});
+						}
+						else 
+						{
+							(this.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(args.entity, {
+								entity: args.entity,
+								property: args.property,
+								oldValue: args.oldValue,
+								newValue: args.newValue
+							});
+						}
 					};
 					this.stepChanged[index] = handler;
 					property.changed.subscribe(handler);

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -88,7 +88,7 @@ export class PropertyChain implements PropertyPath {
 					let handler: PropertyChangeEventHandler;
 					let priorProp: Property = index > 0 ? props[index - 1] : null;
 					handler = args => {
-						if(priorProp) {
+						if (priorProp) {
 							this.rootType.known().forEach(known => {
 								if (this.testConnection(known, args.entity, priorProp)) {
 									(this.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(known, {
@@ -100,8 +100,7 @@ export class PropertyChain implements PropertyPath {
 								}
 							});
 						}
-						else 
-						{
+						else {
 							(this.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(args.entity, {
 								entity: args.entity,
 								property: args.property,

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -11,8 +11,22 @@ function createModel(options): Promise<Model> {
 	});
 }
 
+/*
+    Context
+    Description from Bug 18635:
+    https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/18635
+
+    "A customer on Zendesk had noticed considerable delay before their public form can be interacted with on load. We have noticed anywhere from a ~4s-10s delay when reproducing. The form has a lookup field that references a form with > 7000 entries. This, in and of itself, shouldn't be a big issue. But the field also has 9 cascading filters. We believe this combination is the main contributing factor of the slowdown.
+
+    It appears the bulk of the time is spent looping through lookup entry index instances when initializing lookups. I think this can be optimized in the framework to eliminate this unnecessary work, which would reduce the delay considerable, if not altogether. This would have to be reproduced and the fix tested to prove that it would actually address the problem. Also, the same issue affects Vue forms, so it should at least be fixed there."
+
+    The fix for this is a slight optimization for changes to the first property in a property chain. In the fix, we won't unnecessarily loop over pooled entities to see if they are linked to the changed entity via a null property, because testConnection() would only return true if they are the same entity.
+*/
+
 describe("PropertyChain", () => {
-	it("does something", async () => {
+	it("Doesn't call PropertyChain.testConnection() when not needed", async () => {
+		// To simulate the lookup scenario from the bug above, we create a model that has some type (Person).
+		// This type has multiple properties (GroupName, GroupId, GroupCountry etc...) that references back to one shared object's (Group) properties
 		const model = await createModel({
 			Person: {
 				Name: {
@@ -49,49 +63,51 @@ describe("PropertyChain", () => {
 					  dependsOn: "Group.Language",
 					  function() { return this.Group.Language; }
 					}
-				},
-				GroupXYZ: {
-					type: String,
-					get: {
-					  dependsOn: "Group.XYZ",
-					  function() { return this.Group.XYZ; }
-					}
-				},
-				GroupABC: {
-					type: String,
-					get: {
-					  dependsOn: "Group.ABC",
-					  function() { return this.Group.XYZ; }
-					}
 				}
-
 			},
 			Group: {
 				Name: String,
 				Id: String,
 				Country: String,
-				Language: String,
-				ABC: String,
-				XYZ: String
+				Language: String
 			}
 		});
 
 		const Person = model.getJsType("Person");
-		const chain = (Person.meta as Type).getPath("Group.Name");
 
+		// Create multiple Persons (will just sit in memory)
 		for (let i = 0; i < 1000; i++) {
-			const bryan = new Person({ Name: "Bryan" });
+			const person = new Person({ Name: "Dude Man" });
 		}
 
+		// Create new Group
 		const Group = model.getJsType("Group");
-		const group = new Group({ Name: "Patrick's Group", Id: "XDA-1V9-AM3", Country: "US", Language: "English", XYZ: "XYZ", ABC: "SBC" });
+		const group = new Group({
+			Name: "Test Group",
+			Id: "XDA-1V9-AM3",
+			Country: "US",
+			Language: "English"
+		});
 
+		// Spy on testConnection()
 		const testConnectionSpy = jest.spyOn(PropertyChain.prototype, "testConnection");
 
-		for (let p of (Person.meta as Type).known()) {
-			p.Group = group;
-		}
+		/*
+            For all known Persons, initially assign their Group to be the group constructed above
 
+            Before the fix, this assignment would will trigger recalculations for all of the properties on the Person's container object, which would unnecessarily loop over pooled entities to see if they are linked to the changed entity via a null property. This is where the slowdown comes into play.
+
+            With the fix, we would prevent unnecessarily looping over said entities.
+        */
+		for (let p of (Person.meta as Type).known())
+			p.Group = group;
+
+		//	Assure that testConnection() is not called (we are not unnecessarily looping) on initial assignment
 		expect(testConnectionSpy).not.toBeCalled();
+
+		/*
+            Prior to fix, testConnection() would be called 4,000,000 times
+		    4 (number of dependent properties) * 1000 (Persons in memory) * 1000 (iterations)
+        */
 	});
 });

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -11,22 +11,12 @@ function createModel(options): Promise<Model> {
 	});
 }
 
-/*
-    Context
-    Description from Bug 18635:
-    https://cognitoforms.visualstudio.com/Cognito%20Forms/_workitems/edit/18635
-
-    "A customer on Zendesk had noticed considerable delay before their public form can be interacted with on load. We have noticed anywhere from a ~4s-10s delay when reproducing. The form has a lookup field that references a form with > 7000 entries. This, in and of itself, shouldn't be a big issue. But the field also has 9 cascading filters. We believe this combination is the main contributing factor of the slowdown.
-
-    It appears the bulk of the time is spent looping through lookup entry index instances when initializing lookups. I think this can be optimized in the framework to eliminate this unnecessary work, which would reduce the delay considerable, if not altogether. This would have to be reproduced and the fix tested to prove that it would actually address the problem. Also, the same issue affects Vue forms, so it should at least be fixed there."
-
-    The fix for this is a slight optimization for changes to the first property in a property chain. In the fix, we won't unnecessarily loop over pooled entities to see if they are linked to the changed entity via a null property, because testConnection() would only return true if they are the same entity.
-*/
-
 describe("PropertyChain", () => {
 	it("Doesn't call PropertyChain.testConnection() when not needed", async () => {
-		// To simulate the lookup scenario from the bug above, we create a model that has some type (Person).
-		// This type has multiple properties (GroupName, GroupId, GroupCountry etc...) that references back to one shared object's (Group) properties
+		// To simulate a scenario where calling testConnection would cause a significant performance impact
+		// we create a model that has some type (Person).This type has multiple properties (GroupName, GroupId, GroupCountry etc...)
+		// that references back to one shared object's (Group) properties
+
 		const model = await createModel({
 			Person: {
 				Name: {
@@ -76,6 +66,7 @@ describe("PropertyChain", () => {
 		const Person = model.getJsType("Person");
 
 		// Create multiple Persons (will just sit in memory)
+		// The effect is more pronounced when there are a large number of objects in memory.
 		for (let i = 0; i < 1000; i++) {
 			const person = new Person({ Name: "Dude Man" });
 		}
@@ -92,22 +83,17 @@ describe("PropertyChain", () => {
 		// Spy on testConnection()
 		const testConnectionSpy = jest.spyOn(PropertyChain.prototype, "testConnection");
 
-		/*
-            For all known Persons, initially assign their Group to be the group constructed above
-
-            Before the fix, this assignment would will trigger recalculations for all of the properties on the Person's container object, which would unnecessarily loop over pooled entities to see if they are linked to the changed entity via a null property. This is where the slowdown comes into play.
-
-            With the fix, we would prevent unnecessarily looping over said entities.
-        */
+		// For all known Persons, initially assign their Group to be the group constructed above
+		// Before the fix, this assignment would will trigger recalculations for all of the properties
+		// on the Person's container object, which would unnecessarily loop over pooled entities to
+		// see if they are linked to the changed entity via a null property. This is where the slowdown comes into play.
+		// With the fix, we would prevent unnecessarily looping over said entities.
 		for (let p of (Person.meta as Type).known())
 			p.Group = group;
 
 		//	Assure that testConnection() is not called (we are not unnecessarily looping) on initial assignment
+		//  Prior to fix, testConnection() would be called 4,000,000 times
+		//  4 (number of dependent properties) * 1000 (Persons in memory) * 1000 (iterations)
 		expect(testConnectionSpy).not.toBeCalled();
-
-		/*
-            Prior to fix, testConnection() would be called 4,000,000 times
-		    4 (number of dependent properties) * 1000 (Persons in memory) * 1000 (iterations)
-        */
 	});
 });

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -75,7 +75,6 @@ describe("PropertyChain", () => {
 				XYZ: String
 			}
 		});
-		const testConnectionSpy = jest.spyOn(PropertyChain.prototype, "testConnection");
 
 		const Person = model.getJsType("Person");
 		const chain = (Person.meta as Type).getPath("Group.Name");
@@ -86,6 +85,8 @@ describe("PropertyChain", () => {
 
 		const Group = model.getJsType("Group");
 		const group = new Group({ Name: "Patrick's Group", Id: "XDA-1V9-AM3", Country: "US", Language: "English", XYZ: "XYZ", ABC: "SBC" });
+
+		const testConnectionSpy = jest.spyOn(PropertyChain.prototype, "testConnection");
 
 		for (let p of (Person.meta as Type).known()) {
 			p.Group = group;

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -1,0 +1,96 @@
+import { PropertyChain } from "./property-chain";
+import { Model } from "./model";
+import { Type } from "./type";
+
+function createModel(options): Promise<Model> {
+	return new Promise((resolve) => {
+		let model = new Model(options);
+		model.ready(() => {
+			resolve(model);
+		});
+	});
+}
+
+describe("PropertyChain", () => {
+	it("does something", async () => {
+		const model = await createModel({
+			Person: {
+				Name: {
+					type: String,
+					length: { min: 2, max: 9 }
+				},
+				"Group": {
+					type: "Group"
+				},
+				GroupName: {
+					type: String,
+					get: {
+					  dependsOn: "Group.Name",
+					  function() { return this.Group.Name; }
+					}
+				},
+				GroupId: {
+					type: String,
+					get: {
+					  dependsOn: "Group.Id",
+					  function() { return this.Group.Id; }
+					}
+				},
+				GroupCountry: {
+					type: String,
+					get: {
+					  dependsOn: "Group.Country",
+					  function() { return this.Group.Country; }
+					}
+				},
+				GroupLanguage: {
+					type: String,
+					get: {
+					  dependsOn: "Group.Language",
+					  function() { return this.Group.Language; }
+					}
+				},
+				GroupXYZ: {
+					type: String,
+					get: {
+					  dependsOn: "Group.XYZ",
+					  function() { return this.Group.XYZ; }
+					}
+				},
+				GroupABC: {
+					type: String,
+					get: {
+					  dependsOn: "Group.ABC",
+					  function() { return this.Group.XYZ; }
+					}
+				}
+
+			},
+			Group: {
+				Name: String,
+				Id: String,
+				Country: String,
+				Language: String,
+				ABC: String,
+				XYZ: String
+			}
+		});
+		const testConnectionSpy = jest.spyOn(PropertyChain.prototype, "testConnection");
+
+		const Person = model.getJsType("Person");
+		const chain = (Person.meta as Type).getPath("Group.Name");
+
+		for (let i = 0; i < 1000; i++) {
+			const bryan = new Person({ Name: "Bryan" });
+		}
+
+		const Group = model.getJsType("Group");
+		const group = new Group({ Name: "Patrick's Group", Id: "XDA-1V9-AM3", Country: "US", Language: "English", XYZ: "XYZ", ABC: "SBC" });
+
+		for (let p of (Person.meta as Type).known()) {
+			p.Group = group;
+		}
+
+		expect(testConnectionSpy).not.toBeCalled();
+	});
+});


### PR DESCRIPTION
Description from **[Bug 18635](https://cognitoforms.visualstudio.com/Cognito%20Forms/_queries/edit/18635/?triage=true)**:
"A customer on Zendesk had noticed considerable delay before their public form can be interacted with on load. We have noticed anywhere from a ~4s-10s delay when reproducing. The form has a lookup field that references a form with > 7000 entries. This, in and of itself, shouldn't be a big issue. But the field also has 9 cascading filters. We believe this combination is the main contributing factor of the slowdown.

It appears the bulk of the time is spent looping through lookup entry index instances when initializing lookups. I think this can be optimized in the framework to eliminate this unnecessary work, which would reduce the delay considerable, if not altogether. This would have to be reproduced and the fix tested to prove that it would actually address the problem. Also, the same issue affects Vue forms, so it should at least be fixed there."

This PR reduces the time looping over indexes in `property-chain.js` by only attempting to loop over `rootType.known()` if the `priorProp` is not null.

After running several performance profiles both with the fix and without the fix, I found average page load times for both categories and it turns out that the changes improved performance by ~3 seconds (4300 entries x 9 cascading filters)

**_Page load times without changes_**
~12150 ms
~11970 ms
~13983 ms
~14115 ms
**Average without changes: ~13 seconds**

**_Page load times with changes_**
~13400 ms
~9200 ms
~8980 ms
~8720 ms
**Average with changes: ~10 seconds**
