### PR TITLE
Errors thrown in calculated rules are displayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- errors thrown during rule calculation are logged
+
 ## [0.8.8] - 2020-12-21
-### Added
-- ability to prevent property set if value would violate AllowedValuesRule
+### added
+- ability to prevent property set if value would violate allowedvaluesrule
 
 ## [0.8.7] - 2020-12-11
 ### Changed

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -1,0 +1,59 @@
+import { Model } from "./model";
+
+import "./resource-en";
+
+function createModel(options) {
+	return new Promise((resolve) => {
+		let model = new Model(options);
+		model.ready(() => {
+			resolve(model);
+		});
+	});
+}
+describe("calculated-rule", () => {
+	test("Errors thrown in calculated rules are displayed to the user.", async () => {
+		let consoleOutputs = [];
+		window.console.warn = jest.fn((s)=> consoleOutputs.push(s.toString()));
+		const model = await createModel({
+			Test: {
+				Choice: {
+					label: "Choice",
+					default: {
+						dependsOn: "Text",
+						function: function() { return (this ? this.Text : null); }
+					},
+					allowedValues: {
+						ignoreValidation: true,
+						preventInvalidValues: true,
+						function: function() { return ["First", "Second", "Third"]; }
+					},
+					type: String
+				},
+				Choice_Choices: {
+					label: "Choice_Choices",
+					constant: [
+						{
+							Label: "First"
+						},
+						{
+							Label: "Second"
+						},
+						{
+							Label: "Third"
+						}
+					]
+				},
+				Text: {
+					label: "Text",
+					type: String
+				}
+			}
+		}) as any;
+		const Test = model.getJsType("Test");
+		var p = new Test({ Choice: "First", Text: "First" });
+
+		p.Text = "x";
+
+		expect(consoleOutputs).toEqual(["Error encountered while running rule \"Test.Choice.Calculated\".", "Error: Cannot set Choice, \"x\" is not an allowed value."]);
+	});
+});

--- a/src/event-scope.ts
+++ b/src/event-scope.ts
@@ -93,7 +93,7 @@ export class EventScope {
 				this.current.dispose({ abort: true });
 
 			const errorEvent = (this.onError as Event<EventScope, EventScopeErrorEventArgs>).publish(this, { error: e }) as EventObjectImpl & EventScopeErrorEventArgs;
-			if (!errorEvent.isDefaultPrevented)
+			if (errorEvent === undefined || !errorEvent.isDefaultPrevented)
 				throw e;
 		}
 		finally {

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -321,6 +321,8 @@ function executeRule(rule: Rule, obj: Entity): void {
 	}
 	catch (e) {
 		console.warn(`Error encountered while running rule "${rule.name}".`);
+		if (e)
+			console.warn(e);
 	}
 };
 


### PR DESCRIPTION
Previously an error thrown in a calculated rule would not be printed to the console resulting in a generic error message. With this change we also print out the error that failed in the rule to provide more information.

before
`Error encountered while running rule Test.Calculated.`
after
`Error encountered while running rule Test.Calculated.`
`Error: Cannot set Test, "x" is not an allowed value.`