### PR TITLE
fix model initialization error due to timing of setting Type format

### DIFF
--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -1,0 +1,37 @@
+import { Model } from "./model";
+describe("format", () => {
+	test("format on type does not cause error when creating model", () => {
+		expect(() => new Model({
+			$resources: { "en": { "string-format-alphabetic": "zzzzz" } } as any,
+			"Form": {
+				$format: "[Text]",
+				Text: {
+					label: "Untitled",
+					type: String
+				},
+				Table: {
+					label: "Untitled",
+					type: "Form.Table[]"
+				}
+			},
+			"Form.Table": {
+				Text: {
+					label: "[Text]",
+					labelSource: "Form",
+					format: {
+						reformat: "$&",
+						expression: /^([A-Za-z]+)$/,
+						message: "string-format-alphabetic",
+						description: "Test Format"
+					},
+					type: String
+				},
+				Form: {
+					label: "Form",
+					format: "[Text]",
+					type: "Form"
+				}
+			}
+		})).not.toThrow();
+	});
+});

--- a/src/model.ts
+++ b/src/model.ts
@@ -291,7 +291,8 @@ export class Model {
 
 			// Complete pending model initialization steps
 			this._readyProcessing = true;
-			this._readyCallbacks.forEach(init => init());
+			for (const init of this._readyCallbacks)
+				init();
 			this._readyProcessing = false;
 			delete this._readyCallbacks;
 		}

--- a/src/type.ts
+++ b/src/type.ts
@@ -67,9 +67,7 @@ export class Type {
 		// Set Format
 		if (format) {
 			if (typeof (format) === "string") {
-				this.model.ready(() => {
-					this.format = this.model.getFormat<Entity>(this.jstype, format);
-				});
+				this.format = this.model.getFormat<Entity>(this.jstype, format);
 			}
 			else
 				this.format = format;


### PR DESCRIPTION
`Type` was still setting its `format` within a model ready callback. `ModelFormat` had already been updated to defer format compilation until after the model is ready, so it was incorrect/unnecessary to _set_ the format inside a ready callback. See the added test for an example model which threw an error before the fix.