### PR TITLE
feat: add ability to "persist" an entity graph

### DIFF
--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -2,7 +2,9 @@ import { isEntityType, Type } from "./type";
 import { Entity, EntityConstructorForType } from "./entity";
 import { Property } from "./property";
 import { ObjectLookup, flatMap } from "./helpers";
-import { InitializationContext, AsyncValueResolver } from "./initilization-context";
+import { InitializationContext } from "./initilization-context";
+
+export type AsyncValueResolver = (instance: Entity, property: Property, value: any) => Promise<any> | void;
 
 export interface PropertySerializationResult {
 	key: string;

--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -2,7 +2,7 @@ import { isEntityType, Type } from "./type";
 import { Entity, EntityConstructorForType } from "./entity";
 import { Property } from "./property";
 import { ObjectLookup, flatMap } from "./helpers";
-import { InitializationContext } from "./initilization-context";
+import { InitializationContext, AsyncValueResolver } from "./initilization-context";
 
 export interface PropertySerializationResult {
 	key: string;
@@ -70,6 +70,7 @@ export class EntitySerializer {
 	private _propertyConverters: PropertyConverter[] = [];
 	private _propertyInjectors = new Map<Type | string, PropertyInjector[]>();
 	private _propertyAliases = new Map<Type | string, ObjectLookup<string>>();
+	private _valueResolvers: AsyncValueResolver[] = [];
 	private static defaultPropertyConverter = new PropertyConverter();
 
 	/**
@@ -97,6 +98,10 @@ export class EntitySerializer {
 		let aliases = this._propertyAliases.get(type) || {};
 		aliases[alias] = propertyName;
 		this._propertyAliases.set(type, aliases);
+	}
+
+	registerValueResolver(resolver: AsyncValueResolver) {
+		this._valueResolvers.push(resolver);
 	}
 
 	/**
@@ -215,5 +220,13 @@ export class EntitySerializer {
 
 		propName = this.getPropertyAliases(context.meta.type)[propName];
 		return context.meta.type.getProperty(propName);
+	}
+
+	resolveValue(context: Entity, property: Property, value: any): Promise<any> | void {
+		for (const resolve of this._valueResolvers) {
+			const result = resolve(context, property, value);
+			if (result)
+				return result;
+		}
 	}
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -196,11 +196,17 @@ export class Entity {
 			properties = property;
 
 		if (!this._context) {
+			const wasNew = this.meta.isNew;
 			const context = new InitializationContext(true);
-			context.execute(() => {
-				this.updateWithContext(context, properties);
-			});
-			return context.ready;
+			context.execute(() => this.updateWithContext(context, properties));
+
+			const markPersistedWhenIdAssigned = () => {
+				if (wasNew && !this.meta.isNew)
+					this.markPersisted();
+			};
+
+			context.whenReady(markPersistedWhenIdAssigned);
+			return context.ready.then(markPersistedWhenIdAssigned);
 		}
 
 		// Set the specified properties

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -205,6 +205,8 @@ export class Entity {
 					this.markPersisted();
 			};
 
+			// call markPersistedWhenIdAssigned using whenReady and after the promise resolves to ensure models with no async
+			// behavior produce the correct outcome upon returning from update()
 			context.whenReady(markPersistedWhenIdAssigned);
 			return context.ready.then(markPersistedWhenIdAssigned);
 		}

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -1,8 +1,6 @@
 import { Entity } from "./entity";
 import { Property } from "./property";
 
-export type AsyncValueResolver = (instance: Entity, property: Property, value: any) => Promise<any> | void;
-
 export class InitializationContext {
 	private newDocument = false;
 	private tasks = new Set<Promise<any>>();

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -1,17 +1,15 @@
 import { Entity } from "./entity";
 import { Property } from "./property";
 
-export type InitializationValueResolver = (instance: Entity, property: Property, value: any) => Promise<any>;
+export type AsyncValueResolver = (instance: Entity, property: Property, value: any) => Promise<any> | void;
 
 export class InitializationContext {
 	private newDocument = false;
-	private valueResolver: InitializationValueResolver;
 	private tasks = new Set<Promise<any>>();
 	private waiting: (() => void)[] = [];
 
-	constructor(newDocument: boolean, valueResolver?: InitializationValueResolver) {
+	constructor(newDocument: boolean) {
 		this.newDocument = newDocument;
-		this.valueResolver = valueResolver;
 	}
 
 	/**
@@ -61,7 +59,7 @@ export class InitializationContext {
 	}
 
 	tryResolveValue(instance: Entity, property: Property, value: any) {
-		const task = this.valueResolver && this.valueResolver(instance, property, value);
+		const task = instance.serializer.resolveValue(instance, property, value);
 		if (task)
 			this.wait(task);
 		return task;
@@ -72,6 +70,6 @@ export class InitializationContext {
 	}
 
 	get ready() {
-		return new Promise(resolve => this.whenReady(resolve));
+		return new Promise<void>(resolve => this.whenReady(resolve));
 	}
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -78,13 +78,13 @@ export class Type {
 			this.extend(options);
 	}
 
-	get identifier() {
+	get identifier(): Property {
 		if (this._identifier)
 			return this._identifier;
 		return this.baseType ? this.baseType.identifier : null;
 	}
 
-	set identifier(val) {
+	set identifier(val: Property) {
 		this._identifier = val;
 	}
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -8,7 +8,6 @@ import { RuleOptions, Rule } from "./rule";
 import { Format } from "./format";
 import { PropertyChain } from "./property-chain";
 import { PropertyPath } from "./property-path";
-import { InitializationContext, InitializationValueResolver } from "./initilization-context";
 
 export const Type$newIdPrefix = "+c";
 
@@ -89,27 +88,19 @@ export class Type {
 	}
 
 	createSync(state: any): Entity {
-		// Attempt to fetch an existing instance if the state contains an Id property
 		const id = getIdFromState(this, state);
-		if (id) {
-			const instance = this.get(id);
-			if (instance) {
-				// Assign state to the existing object
-				instance.set(state);
-				return instance;
-			}
-			const Ctor = this.jstype as any;
-			// Construct an instance using the known id
-			return new Ctor(id, state);
-		}
-		// Construct a new instance without a known id
-		return new this.jstype(state);
+		if (id && this.get(id))
+			throw new Error(`Could not create instance of type '${this.fullName}' with identifier '${id}' because this object already exists.`);
+
+		const Ctor = this.jstype as any;
+		// Construct an instance using the known id if it is present
+		const instance = (id ? new Ctor(id, state) : new Ctor(state)) as Entity;
+		return instance;
 	}
 
-	create(state: any, valueResolver?: InitializationValueResolver): Promise<Entity> {
-		// Attempt to fetch an existing instance if the state contains an Id property
-		const { context, instance } = Type$createOrUpdate(this, state, valueResolver);
-		return new Promise(resolve => context.whenReady(() => resolve(instance)));
+	create(state: any): Promise<Entity> {
+		const instance = this.createSync(state);
+		return instance.initialized.then(() => instance);
 	}
 
 	/** Generates a unique id suitable for an instance in the current type hierarchy. */
@@ -194,7 +185,7 @@ export class Type {
 		}
 
 		obj.meta.id = newId;
-		obj.meta.isNew = false;
+		obj.markPersisted();
 
 		return obj;
 	}
@@ -492,36 +483,6 @@ export class Type {
 			}
 		});
 	}
-}
-
-export function Type$createOrUpdate(type: Type, state: any, contextOrResolver: InitializationValueResolver | InitializationContext) {
-	const id = getIdFromState(type, state);
-	const isNew = !id;
-	let context: InitializationContext;
-	if (contextOrResolver instanceof InitializationContext)
-		context = contextOrResolver;
-	else
-		context = new InitializationContext(isNew, contextOrResolver);
-
-	// We need to pause processing of callbacks to prevent publishing entity events while still processing
-	// the state graph
-	const instance = context.execute(() => {
-		let instance = id && type.get(id);
-		if (instance) {
-			// Assign state to the existing object
-			instance.updateWithContext(context, state);
-		}
-		else {
-			// Cast the jstype to any so we can call the internal constructor signature that takes a context
-			// We don't want to put the context on the public constructor interface
-			const Ctor = type.jstype as any;
-			// Construct an instance using the known id if it is present
-			instance = (id ? new Ctor(id, state, context) : new Ctor(state, context)) as Entity;
-		}
-		return instance;
-	});
-
-	return { context, instance };
 }
 
 export type Value = string | number | Date | boolean;

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -17,109 +17,95 @@ describe("Type", () => {
 		expect(model.types.Sub.identifier).toBe(model.types.Base.identifier);
 	});
 
-	test("createOrUpdate should support multilevel async resolution", async () => {
-		const model = new Model({
-			Sibling: {
-				Id: { identifier: true, type: String },
-				Name: String
-			},
-			Child: {
-				Id: { identifier: true, type: String },
-				Sibling: "Sibling",
-				Name: String
-			},
-			Parent: {
-				Id: { identifier: true, type: String },
-				Child: "Child"
-			}
+	describe("create", () => {
+		it("should support multilevel async resolution", async () => {
+			const model = new Model({
+				Sibling: {
+					Id: { identifier: true, type: String },
+					Name: String
+				},
+				Child: {
+					Id: { identifier: true, type: String },
+					Sibling: "Sibling",
+					Name: String
+				},
+				Parent: {
+					Id: { identifier: true, type: String },
+					Child: "Child"
+				}
+			});
+
+			model.serializer.registerValueResolver((instance, prop, value) => {
+				if (prop.name === "Child")
+					return Promise.resolve({ Id: value, Name: "Child Name", Sibling: "5" });
+				if (prop.name === "Sibling")
+					return Promise.resolve({ Id: value, Name: "Sibling Name" });
+			});
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			let parent = await model.types.Parent.create({ Child: "1" });
+			console.log("test after await");
+			expect((parent as any).Child.Sibling.Name).toBe("Sibling Name");
 		});
 
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		let parent = await model.types.Parent.create({ Child: "1" }, (instance, prop, value) => {
-			if (prop.name === "Child")
-				return Promise.resolve({ Id: value, Name: "Child Name", Sibling: "5" });
-			if (prop.name === "Sibling")
-				return Promise.resolve({ Id: value, Name: "Sibling Name" });
-		});
-		expect((parent as any).Child.Sibling.Name).toBe("Sibling Name");
-	});
-
-	/**
+		/**
 	 * The core issue here was that any task queued on an InitializationContext as a result of a ready() callback
 	 * would not prevent further processing of the waiting queue.
 	 */
-	test("createOrUpdate should support multilevel async resolution within list items", async () => {
-		const model = new Model({
-			Lookup: {
-				Id: { identifier: true, type: String },
-				Name: String
-			},
-			ListItem: {
-				Lookup: "Lookup"
-			},
-			Parent: {
-				Id: { identifier: true, type: String },
-				List: "ListItem[]"
-			}
+		it("should support multilevel async resolution within list items", async () => {
+			const model = new Model({
+				Lookup: {
+					Id: { identifier: true, type: String },
+					Name: String
+				},
+				ListItem: {
+					Lookup: "Lookup"
+				},
+				Parent: {
+					Id: { identifier: true, type: String },
+					List: "ListItem[]"
+				}
+			});
+
+			const db = {
+				Lookup: {
+					"a": { Id: "a", Name: "Lookup A" },
+					"b": { Id: "B", Name: "Lookup B" }
+				}
+			};
+
+			model.serializer.registerValueResolver((instance, prop, value) => {
+				if (db[prop.propertyType.name])
+					return new Promise(resolve => setTimeout(() => resolve(db[prop.propertyType.name][value]), 10));
+			});
+
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			await model.types.Parent.create({
+				List: [
+					{ Lookup: "a" },
+					{ Lookup: "b" }
+				]
+			});
+			const parent = await model.types.Parent.create({
+				List: [
+					{ Lookup: "a" },
+					{ Lookup: "b" }
+				]
+			});
+			expect((parent as any).List[1].Lookup.Name).toBe("Lookup B");
 		});
 
-		const db = {
-			Lookup: {
-				"a": { Id: "a", Name: "Lookup A" },
-				"b": { Id: "B", Name: "Lookup B" }
-			}
-		};
+		it("should throw error when asked to create an entity which already exists", async () => {
+			const model = new Model({
+				Entity: {
+					Id: { identifier: true, type: String },
+					Name: String,
+					Sibling: "Entity"
+				}
+			});
 
-		const valueResolver = (instance, prop, value) => {
-			if (db[prop.propertyType.name])
-				return new Promise(resolve => setTimeout(() => resolve(db[prop.propertyType.name][value]), 10));
-		};
-		// eslint-disable-next-line @typescript-eslint/no-unused-vars
-		await model.types.Parent.create({
-			List: [
-				{ Lookup: "a" },
-				{ Lookup: "b" }
-			]
-		}, valueResolver);
-		const parent = await model.types.Parent.create({
-			List: [
-				{ Lookup: "a" },
-				{ Lookup: "b" }
-			]
-		}, valueResolver);
-		expect((parent as any).List[1].Lookup.Name).toBe("Lookup B");
-	});
-
-	test("createOrUpdate should support circular async resolution after entities already exist", async () => {
-		const model = new Model({
-			Entity: {
-				Id: { identifier: true, type: String },
-				Name: String,
-				Sibling: "Entity"
-			}
+			await model.types.Entity.create({ Id: "x" });
+			expect(() => model.types.Entity.create({ Id: "x" })).toThrow(/already exists/);
 		});
-
-		const entities = {
-			a: {
-				Id: "a",
-				Name: "Entity A",
-				Sibling: "b"
-			},
-			b: {
-				Id: "b",
-				Name: "Entity B",
-				Sibling: "a"
-			}
-		};
-
-		const siblingResolver = (instance, prop, value) => {
-			if (prop.name === "Sibling")
-				return new Promise(resolve => setTimeout(() => resolve(entities[value]), 10));
-		};
-
-		// ensure entity instances already exist and are pooled
-		await model.types.Entity.create(entities.a, siblingResolver);
-		let root = await model.types.Entity.create(entities.a, siblingResolver);
-		expect((root as any).Sibling.Sibling).toBe(root);
 	});
 });


### PR DESCRIPTION
The only effect of calling this method would be marking entity meta objects as not "new". In essence, it is a way to reflect to the model that some outside notion of persistence was performed.