### PR TITLE
Added afterPropertySet, listChanged global events and tests

### DIFF
--- a/src/events.ts
+++ b/src/events.ts
@@ -38,7 +38,7 @@ export interface EventSubscriptionChanged<EventType> {
     (event: EventType): void;
 }
 
-function createEventObject<EventArgsType>(args: EventArgsType): EventObject & EventArgsType {
+export function createEventObject<EventArgsType>(args: EventArgsType): EventObject & EventArgsType {
 	let eventObject: EventObject = new EventObjectImpl();
 
 	for (var prop in args) {

--- a/src/list-length-rule.unit.ts
+++ b/src/list-length-rule.unit.ts
@@ -27,7 +27,6 @@ describe("ListLengthRule", () => {
 				Text: {
 					type: String
 				}
-
 			}
 		}) as any;
 		const Test = model.getJsType("Test");

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,6 @@
 import { Event, EventSubscriber } from "./events";
 import { replaceTokens, ObjectLookup } from "./helpers";
-import { EntityRegisteredEventArgs, Entity } from "./entity";
+import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs } from "./entity";
 import { Type, PropertyType, isEntityType, ValueType, TypeOptions, TypeExtensionOptions } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
@@ -21,6 +21,8 @@ export class Model {
 	readonly $culture: CultureInfo;
 
 	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs>;
+	readonly afterPropertySet: Event<Entity, EntityChangeEventArgs>;
+	readonly listChanged: Event<Entity, EntityChangeEventArgs>;
 	readonly eventScope: EventScope;
 
 	private _readyCallbacks: (() => void)[];
@@ -33,6 +35,8 @@ export class Model {
 		this.types = {};
 		this.settings = new ModelSettings(config);
 		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs>();
+		this.afterPropertySet = new Event<Entity, EntityChangeEventArgs>();
+		this.listChanged = new Event<Entity, EntityChangeEventArgs>();
 		this.eventScope = EventScope.create(this.settings.eventScopeSettings);
 
 		Object.defineProperty(this, "_formats", { enumerable: false, configurable: false, writable: true, value: {} });

--- a/src/model.ts
+++ b/src/model.ts
@@ -21,8 +21,8 @@ export class Model {
 	readonly $culture: CultureInfo;
 
 	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs>;
-	readonly afterPropertySet: Event<Entity, EntityChangeEventArgs>;
-	readonly listChanged: Event<Entity, EntityChangeEventArgs>;
+	readonly afterPropertySet: EventSubscriber<Entity, EntityChangeEventArgs>;
+	readonly listChanged: EventSubscriber<Entity, EntityChangeEventArgs>;
 	readonly eventScope: EventScope;
 
 	private _readyCallbacks: (() => void)[];

--- a/src/property.ts
+++ b/src/property.ts
@@ -946,7 +946,7 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 		(eventArgs as any)["changes"] = args.changes;
 		(eventArgs as any)["collectionChanged"] = true;
 
-		property.containingType.model.listChanged.publish(obj, { entity: obj, property, newValue: array });
+		(property.containingType.model.listChanged as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue: array });
 		(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, eventArgs);
 		(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue: array });
 	});
@@ -1079,9 +1079,9 @@ function Property$setValue(property: Property, obj: Entity, currentValue: any, n
 		// Do not raise change if the property has not been initialized.
 		if (oldValue !== undefined) {
 			var eventArgs: PropertyChangeEventArgs = { entity: obj, property, newValue, oldValue };
+			(property.containingType.model.afterPropertySet as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue, oldValue });
 			(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, additionalArgs ? merge(eventArgs, additionalArgs) : eventArgs);
 			(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, oldValue, newValue });
-			property.containingType.model.afterPropertySet.publish(obj, { entity: obj, property, newValue, oldValue });
 		}
 	}
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -946,6 +946,7 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 		(eventArgs as any)["changes"] = args.changes;
 		(eventArgs as any)["collectionChanged"] = true;
 
+		property.containingType.model.listChanged.publish(obj, { entity: obj, property, newValue: array });
 		(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, eventArgs);
 		(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue: array });
 	});
@@ -1080,6 +1081,7 @@ function Property$setValue(property: Property, obj: Entity, currentValue: any, n
 			var eventArgs: PropertyChangeEventArgs = { entity: obj, property, newValue, oldValue };
 			(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, additionalArgs ? merge(eventArgs, additionalArgs) : eventArgs);
 			(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, oldValue, newValue });
+			property.containingType.model.afterPropertySet.publish(obj, { entity: obj, property, newValue, oldValue });
 		}
 	}
 }


### PR DESCRIPTION
Added afterPropertySet - emits an event when a property that is not a list is changed
Added listChanged - emits an event when a property that is a list is changed