### PR TITLE
feat: default value calculations run on existing entities

### DIFF
--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -32,14 +32,13 @@ export class CalculatedPropertyRule extends Rule {
 			if (options.property) {
 				property = typeof options.property === "string" ? rootType.getProperty(options.property) as Property : options.property as Property;
 
-				if (!options.isDefaultValue) {
-					// indicate that the rule is responsible for returning the value of the calculated property
-					options.returns = [property];
-				}
-				else {
+				if (options.isDefaultValue) {
 					// Ensure the default value rule runs on init of a new instance
 					(options as RuleInvocationOptions).onInitNew = true;
 				}
+
+				// indicate that the rule is responsible for returning the value of the calculated property
+				options.returns = [property];
 			}
 
 			if (!name) {
@@ -68,8 +67,8 @@ export class CalculatedPropertyRule extends Rule {
 		// register the rule with the target property
 		this.property.rules.push(this);
 
-		// mark the property as calculated if the rule runs on property access
-		if (this.invocationTypes & RuleInvocationType.PropertyGet)
+		// mark the property as calculated if the rule runs on property access and is not a default value calculation
+		if (!options.isDefaultValue && this.invocationTypes & RuleInvocationType.PropertyGet)
 			this.property.isCalculated = true;
 	}
 

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -71,21 +71,21 @@ describe("CalculateRule", () => {
 
 		describe("on new instance", () => {
 			it("can be based on other default value", async () => {
-				const entity = TestEntity.createSync({});
+				const entity = await TestEntity.create({});
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBe("John Doe");
 			});
 
 			it("is overridden by non-null value provided during construction", async () => {
-				const entity = TestEntity.createSync({ Name: "New Name" });
+				const entity = await TestEntity.create({ Name: "New Name" });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBe("New Name");
 			});
 
 			it("is overridden by null value provided during construction", async () => {
-				const entity = TestEntity.createSync({ Name: null });
+				const entity = await TestEntity.create({ Name: null });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBeNull();
@@ -94,28 +94,28 @@ describe("CalculateRule", () => {
 
 		describe("on existing instance", () => {
 			it("can be based on other default value", async () => {
-				const entity = TestEntity.createSync({ Id: "1" });
+				const entity = await TestEntity.create({ Id: "1" });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBe("John Doe");
 			});
 
 			it("can be based on other default value", async () => {
-				const entity = TestEntity.createSync({ Id: "1" });
+				const entity = await TestEntity.create({ Id: "1" });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBe("John Doe");
 			});
 
 			it("is overridden by non-null value provided during construction", async () => {
-				const entity = TestEntity.createSync({ Id: "1", Name: "New Name" });
+				const entity = await TestEntity.create({ Id: "1", Name: "New Name" });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBe("New Name");
 			});
 
 			it("is overridden by null value provided during construction", async () => {
-				const entity = TestEntity.createSync({ Id: "1", Name: null });
+				const entity = await TestEntity.create({ Id: "1", Name: null });
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBeNull();

--- a/src/property.ts
+++ b/src/property.ts
@@ -840,73 +840,6 @@ export function Property$generateOwnProperty(property: Property, obj: Entity): v
 	});
 }
 
-// TODO: Get rid of `Property$_generateOwnPropertyWithClosure`...
-export function Property$generateOwnPropertyWithClosure(property: Property, obj: Entity): void {
-	let val: any = null;
-
-	let isInitialized = false;
-
-	var _ensureInited = function (): void {
-		if (!isInitialized) {
-			// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
-			if (!property.isCalculated) {
-				Property$pendingInit(obj, property, false);
-
-				val = Property$getInitialValue(property);
-
-				if (Array.isArray(val)) {
-					Property$subArrayEvents(obj, property, val as ObservableArray<any>);
-				}
-
-				// TODO: Account for static properties (obj is undefined)
-				(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property: property, newValue: val });
-			}
-
-			// Mark the property as pending initialization
-			Property$pendingInit(obj, property, true);
-
-			isInitialized = true;
-		}
-	};
-
-	Object.defineProperty(obj, property.name, {
-		configurable: false,
-		enumerable: true,
-		get: function () {
-			_ensureInited();
-
-			// Raise get events
-			(property.accessed as EventPublisher<Entity, PropertyAccessEventArgs>).publish(obj, { entity: obj, property, value: val });
-
-			return val;
-		},
-		set: function (newVal) {
-			_ensureInited();
-
-			if (Property$shouldSetValue(property, obj, val, newVal)) {
-				// Update lists as batch remove/add operations
-				if (property.isList) {
-					let currentArray = val as ObservableArray<any>;
-					currentArray.batchUpdate((array) => {
-						updateArray(array, newVal);
-					});
-				}
-				else {
-					let old = val;
-					val = newVal;
-
-					Property$pendingInit(obj, property, false);
-
-					// Do not raise change if the property has not been initialized.
-					if (old !== undefined) {
-						(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, { entity: obj, property, newValue: val, oldValue: old });
-					}
-				}
-			}
-		}
-	});
-}
-
 export function Property$pendingInit(obj: Entity, prop: Property, value: boolean = null): boolean | void {
 	let pendingInit: ObjectLookup<boolean>;
 
@@ -984,16 +917,16 @@ export function Property$init(property: Property, obj: Entity, val: any): void {
 }
 
 function Property$ensureInited(property: Property, obj: Entity): void {
-	// Determine if the property has been initialized with a value
-	// and initialize the property if necessary
+	// Determine if the property has been initialized with a value and initialize the property if necessary
 	if (!obj.__fields__.hasOwnProperty(property.name)) {
-		// Mark the property as pending initialization
-		Property$pendingInit(obj, property, true);
-
 		// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
 		if (!property.isCalculated) {
 			Property$init(property, obj, Property$getInitialValue(property));
 		}
+
+		// Mark the property as pending initialization if it still has no underlying value to allow default calculation rules to run for it
+		if (obj.__fields__[property.name] === null)
+			Property$pendingInit(obj, property, true);
 	}
 }
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -919,14 +919,16 @@ export function Property$init(property: Property, obj: Entity, val: any): void {
 function Property$ensureInited(property: Property, obj: Entity): void {
 	// Determine if the property has been initialized with a value and initialize the property if necessary
 	if (!obj.__fields__.hasOwnProperty(property.name)) {
+		Property$pendingInit(obj, property, true);
+
 		// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
 		if (!property.isCalculated) {
 			Property$init(property, obj, Property$getInitialValue(property));
-		}
 
-		// Mark the property as pending initialization if it still has no underlying value to allow default calculation rules to run for it
-		if (obj.__fields__[property.name] === null)
-			Property$pendingInit(obj, property, true);
+			// Mark the property as pending initialization if it still has no underlying value to allow default calculation rules to run for it
+			if (obj.__fields__[property.name] === null)
+				Property$pendingInit(obj, property, true);
+		}
 	}
 }
 


### PR DESCRIPTION
When initializing an "existing" entity, default value calculation rules will run for properties with no value specified in the initial state for the entity.

```ts
// assuming Name is defaulted to "John Doe"
const e1 = await SomeType.create({ Id: "1" });
console.log(e1.Name);  // John Doe

const e2 = await SomeType.create({ Id: "2", Name: null });
console.log(e2.Name);  // null
```