### PR TITLE
Fix format errors with tokenized labels to display the correct label

### DIFF
--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -1,6 +1,6 @@
 import { ErrorConditionType } from "./condition-type";
 import { Entity } from "./entity";
-import { Property } from "./property";
+import { evaluateLabel, Property } from "./property";
 import { Condition } from "./condition";
 import { Format } from "./format";
 
@@ -22,7 +22,7 @@ export class FormatError {
 	}
 
 	createCondition(target: Entity, prop: Property): Condition {
-		return new Condition(FormatError.ConditionType, this.messageTemplate.replace("{property}", prop.label), target, this.format, [prop]);
+		return new Condition(FormatError.ConditionType, this.messageTemplate.replace("{property}", evaluateLabel(prop, target)), target, this.format, [prop]);
 	}
 
 	toString(): string {


### PR DESCRIPTION
use evaluateLabel() to properly get tokenized label