### PR TITLE
add: Type.createIfNotExists

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -87,6 +87,20 @@ export class Type {
 		this._identifier = val;
 	}
 
+	createIfNotExists(state: any): Entity {
+		const id = getIdFromState(this, state);
+		if (id) {
+			const existing = this.get(id);
+			if (existing)
+				return existing;
+		}
+
+		const Ctor = this.jstype as any;
+		// Construct an instance using the known id if it is present
+		const instance = (id ? new Ctor(id, state) : new Ctor(state)) as Entity;
+		return instance;
+	}
+
 	createSync(state: any): Entity {
 		const id = getIdFromState(this, state);
 		if (id && this.get(id))

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -108,4 +108,35 @@ describe("Type", () => {
 			expect(() => model.types.Entity.create({ Id: "x" })).toThrow(/already exists/);
 		});
 	});
+
+	describe("createIfNotExists", () => {
+		let model: Model;
+		beforeEach(() => {
+			model = new Model({
+				Entity: {
+					Id: { identifier: true, type: String },
+					Name: String,
+					Sibling: "Entity"
+				}
+			});
+		});
+
+		it("should create new instance if id is not known", () => {
+			const entity = model.types.Entity.createIfNotExists({ Id: "x", Name: "Test123" });
+			expect(entity.Id).toBe("x");
+			expect(entity.Name).toBe("Test123");
+		});
+
+		it("should create new instance if id is not provided", () => {
+			const entity = model.types.Entity.createIfNotExists({ Name: "Test123" });
+			expect(entity.Id).toBeNull();
+			expect(entity.Name).toBe("Test123");
+		});
+
+		it("should return known instance if id is known", () => {
+			const known = model.types.Entity.createSync({ Id: "x", Name: "Test123" });
+			expect(model.types.Entity.createIfNotExists({ Id: "x", Name: "New123" })).toBe(known);
+			expect(known.Name).toBe("Test123");
+		});
+	});
 });


### PR DESCRIPTION
In order to support certain scenarios that previously worked, but now don't since `create` was changed to throw an error for known entity ids, a `createIfNotExists` method has been added to `Type`.