### PR TITLE
ensure async property values are initialized before publishing initExisting event

### DIFF
--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -221,6 +221,21 @@ describe("Entity", () => {
 			expect(movie.Budget.serialize()).toEqual(Budget1);
 		});
 
+		it("asynchronous property is initialized before initExisting event published ", async () => {
+			const Budget1 = { LineItems: [{ Label: "L1", Cost: 1000000 }] };
+
+			model.serializer.registerValueResolver((entity, prop, value) => {
+				if (prop.name === "Budget" && value === "BUDGET_1")
+					return Promise.resolve(Budget1);
+			});
+
+			Types.Movie.meta.initExisting.subscribe(({ entity: movie }) => {
+				expect(movie.Budget.serialize()).toEqual(Budget1);
+			});
+
+			await Types.Movie.meta.create({ ...Alien, Id: "1", Budget: "BUDGET_1" });
+		});
+
 		it("should support circular async value resolution", async () => {
 			const model = new Model({
 				Entity: {

--- a/src/initilization-context.ts
+++ b/src/initilization-context.ts
@@ -30,9 +30,11 @@ export class InitializationContext {
 	wait(task: Promise<any>) {
 		this.tasks.add(task);
 		task.then(() => {
-			this.tasks.delete(task);
 			// process the queue asynchronously to allow additional tasks to be queued as a result of this one
-			Promise.resolve().then(() => this.processWaitingQueue());
+			Promise.resolve().then(() => {
+				this.tasks.delete(task);
+				this.processWaitingQueue();
+			});
 		});
 	}
 


### PR DESCRIPTION
When an entity is created, it should not be considered "fully initialized" until any asynchronously loaded property values have resolved, and are assigned. This timing issue was particularly problematic for rules which depended on a property whose value was asynchronously resolved. The order of events would look something like this:
1. entity begins creation (`Type.create()`)
2. a property with async value resolution enabled is encountered, we queue the task to load the data needed to init the property
3. the task completes, _but the property has not been initialized yet_
4. meanwhile, the rest of the entity is done initializing and the initialization context is deemed "ready"
4. `initExisting` event is published
5. "on init" rule runs, while value of our property is `null`
4. the async property is then initialized
5. the rule does not rerun because the property was not technically updated, but rather initialized
6. model is now in an inconsistent state