### PR TITLE
Allow condition messages to be a function, allowing reactivity

### DIFF
--- a/src/condition.ts
+++ b/src/condition.ts
@@ -10,7 +10,7 @@ import { Format } from "./format";
 
 export class Condition {
 	type: ConditionType;
-	message: string;
+	_message: string | Function;
 	targets: ObservableArray<ConditionTarget>;
 	source: Rule | Format<any>;
 
@@ -21,7 +21,7 @@ export class Condition {
 		* @param target The root target entity the condition is associated with.
 		* @param properties The set of property paths specifying which properties and entities the condition should be attached to.
 		*/
-	constructor(type: ConditionType, message: string, target: Entity, source: Rule | Format<any>, properties: PropertyPath[] = []) {
+	constructor(type: ConditionType, message: string | Function, target: Entity, source: Rule | Format<any>, properties: PropertyPath[] = []) {
 		this.type = type;
 		this.message = message || (type ? type.message : undefined);
 		let targets = this.targets = ObservableArray.create<ConditionTarget>();
@@ -81,6 +81,17 @@ export class Condition {
 				}
 			}
 		}
+	}
+
+	get message(): string {
+		if (typeof(this._message) === "string")
+			return this._message;
+		else
+			return this._message();
+	}
+
+	set message(val: string | Function) {
+		this._message = val;
 	}
 
 	destroy(): void {

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -23,7 +23,7 @@ export class Condition {
 		*/
 	constructor(type: ConditionType, message: string | Function, target: Entity, source: Rule | Format<any>, properties: PropertyPath[] = []) {
 		this.type = type;
-		this.message = message || (type ? type.message : undefined);
+		this._message = message || (type ? type.message : undefined);
 		let targets = this.targets = ObservableArray.create<ConditionTarget>();
 		this.source = source;
 
@@ -90,7 +90,7 @@ export class Condition {
 			return this._message();
 	}
 
-	set message(val: string | Function) {
+	set message(val: string) {
 		this._message = val;
 	}
 

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -10,7 +10,7 @@ import { Format } from "./format";
 
 export class Condition {
 	type: ConditionType;
-	_message: string | Function;
+	private _message: string | (() => string);
 	targets: ObservableArray<ConditionTarget>;
 	source: Rule | Format<any>;
 
@@ -21,7 +21,7 @@ export class Condition {
 		* @param target The root target entity the condition is associated with.
 		* @param properties The set of property paths specifying which properties and entities the condition should be attached to.
 		*/
-	constructor(type: ConditionType, message: string | Function, target: Entity, source: Rule | Format<any>, properties: PropertyPath[] = []) {
+	constructor(type: ConditionType, message: string | (() => string), target: Entity, source: Rule | Format<any>, properties: PropertyPath[] = []) {
 		this.type = type;
 		this._message = message || (type ? type.message : undefined);
 		let targets = this.targets = ObservableArray.create<ConditionTarget>();

--- a/src/format-error.ts
+++ b/src/format-error.ts
@@ -22,7 +22,7 @@ export class FormatError {
 	}
 
 	createCondition(target: Entity, prop: Property): Condition {
-		return new Condition(FormatError.ConditionType, this.messageTemplate.replace("{property}", evaluateLabel(prop, target)), target, this.format, [prop]);
+		return new Condition(FormatError.ConditionType, () => this.messageTemplate.replace("{property}", evaluateLabel(prop, target)), target, this.format, [prop]);
 	}
 
 	toString(): string {

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -1,4 +1,7 @@
+import { FormatError } from "./format-error";
 import { Model } from "./model";
+import "./resource-en";
+
 describe("format", () => {
 	test("format on type does not cause error when creating model", () => {
 		expect(() => new Model({
@@ -33,5 +36,30 @@ describe("format", () => {
 				}
 			}
 		})).not.toThrow();
+	});
+
+	test("Format errors where the label has a token stay updated", async () => {
+		let model = new Model({
+			Form: {
+				Text: {
+					label: "Text",
+					type: String
+				},
+				Number: {
+					label: "[Text]",
+					default: null,
+					format: "N0",
+					type: Number
+				}
+			}
+		});
+		let form = await model.types.Form.create({});
+		form.Text = "label1";
+		var val = model.types.Form.jstype.$Number.format.convertBack("test") as FormatError;
+		var error = val.createCondition(form, model.types.Form.jstype.$Number);
+
+		expect(error.message).toBe("label1 must be formatted as #,###.");
+		form.Text = "label2";
+		expect(error.message).toBe("label2 must be formatted as #,###.");
 	});
 });


### PR DESCRIPTION
There wasn't a way to create a condition with a reactive message, so I allowed for a message to be passed in as a function. So messages where the property label has tokens are able to be made into functions making them reactive.