### PR TITLE
Add support for lists with formatting

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -277,8 +277,8 @@ export class ModelFormat<T extends Entity> extends Format<T> {
 			return "";
 		}
 
-		var result = "";
-		const convertTokens = (obj: T) => {
+		const convertTokens = (obj: T): string => {
+			var result = "";
 			for (var index = 0; index < this.tokens.length; index++) {
 				var token = this.tokens[index];
 				if (token.prefix)
@@ -308,18 +308,13 @@ export class ModelFormat<T extends Entity> extends Format<T> {
 					result = result + value;
 				}
 			}
+			return result;
 		};
 
 		if (Array.isArray(obj))
-			obj.forEach((item, index)=>{
-				convertTokens(item);
-				if (index !== obj.length - 1)
-					result += ", ";
-			});
+			return obj.map(item => convertTokens(item)).join(", ");
 		else
-			convertTokens(obj);
-
-		return result;
+			return convertTokens(obj);
 	}
 
 	convertFromString(): FormatError | T {

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -63,7 +63,7 @@ describe("format", () => {
 		expect(error.message).toBe("label2 must be formatted as #,###.");
 	});
 
-	test("lists", async () => {
+	test("list items are formatted using the list property format", async () => {
 		var model = new Model({
 			"Form": {
 				Table: {
@@ -81,16 +81,8 @@ describe("format", () => {
 				}
 			},
 			"Form.Table": {
-				Text1: {
-					label: "Text1",
-					default: "Text1",
-					type: String
-				},
-				Text2: {
-					label: "Text2",
-					default: "Text1",
-					type: String
-				}
+				Text1: String,
+				Text2: String
 			}
 		});
 		let form = await model.types.Form.create({}) as any;

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -53,7 +53,7 @@ describe("format", () => {
 				}
 			}
 		});
-		let form = await model.types.Form.create({});
+		let form = await model.types.Form.create({}) as any;
 		form.Text = "label1";
 		var val = model.types.Form.jstype.$Number.format.convertBack("test") as FormatError;
 		var error = val.createCondition(form, model.types.Form.jstype.$Number);
@@ -61,5 +61,39 @@ describe("format", () => {
 		expect(error.message).toBe("label1 must be formatted as #,###.");
 		form.Text = "label2";
 		expect(error.message).toBe("label2 must be formatted as #,###.");
+	});
+
+	test("lists", async () => {
+		var model = new Model({
+			"Form": {
+				Table: {
+					label: "table",
+					type: "Form.Table[]",
+					format: "[Text2]",
+					default: () => [{
+						Text1: "Text1",
+						Text2: "Text2"
+					},
+					{
+						Text1: "Text1",
+						Text2: "Text2"
+					}]
+				}
+			},
+			"Form.Table": {
+				Text1: {
+					label: "Text1",
+					default: "Text1",
+					type: String
+				},
+				Text2: {
+					label: "Text2",
+					default: "Text1",
+					type: String
+				}
+			}
+		});
+		let form = await model.types.Form.create({}) as any;
+		expect(form.toString("[Table]")).toBe("Text2, Text2");
 	});
 });


### PR DESCRIPTION
For lists `obj` in `convertToString()` was an array and we were not properly getting the format for the items in the list.