### PR TITLE
Avoid prepending format token prefix for empty results

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -281,8 +281,6 @@ export class ModelFormat<T extends Entity> extends Format<T> {
 			var result = "";
 			for (var index = 0; index < this.tokens.length; index++) {
 				var token = this.tokens[index];
-				if (token.prefix)
-					result = result + token.prefix;
 				if (token.path) {
 					var value = evalPath(obj, token.path);
 					if (value === undefined || value === null) {
@@ -304,6 +302,9 @@ export class ModelFormat<T extends Entity> extends Format<T> {
 
 					if (Array.isArray(value))
 						value = value.join(", ");
+
+					if (token.prefix && result !== "" && value !== "")
+						result = result + token.prefix;
 
 					result = result + value;
 				}

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -88,4 +88,40 @@ describe("format", () => {
 		let form = await model.types.Form.create({}) as any;
 		expect(form.toString("[Table]")).toBe("Text2, Text2");
 	});
+
+	test("Prefixes are not prepended if there is no value and result", async () => {
+		var model = new Model({
+			"Form": {
+				Name: {
+					label: "Name",
+					format: "[Prefix] [First] [MiddleInitial] [Last] [Suffix]",
+					type: "Name"
+				}
+			},
+			"Name": {
+				First: {
+				  label: "First",
+				  type: String
+				},
+				Last: {
+				  label: "Last",
+				  type: String
+				},
+				MiddleInitial: {
+				  label: "Middle Initial",
+				  type: String
+				},
+				Prefix: {
+				  label: "Prefix",
+				  type: String
+				},
+				Suffix: {
+				  label: "Suffix",
+				  type: String
+				}
+			  }
+		});
+		let form = await model.types.Form.create({ Name: { First: "John", Last: "Doe" } }) as any;
+		expect(form.toString("[Name]")).toBe("John Doe");
+	});
 });


### PR DESCRIPTION
**Problem**
We were adding the tokens prefix when ever it was available which was causing extra spaces when formatting if there were properties without a value.
`Ex. "[Prefix] [First] [MiddleInitial] [Last] [Suffix]" => " John  Doe "`
**Fix**
Avoid adding the prefix if the result and value are empty strings.
