### PR TITLE
Ensure that the Boolean formatter is not affected by whitespace when parsing input

### DIFF
--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -44,7 +44,7 @@ describe("CalculateRule", () => {
 		expect(consoleOutputs).toEqual(["Error encountered while running rule \"Test.Choice.Calculated\".", "Error: Cannot set Choice, \"x\" is not an allowed value."]);
 	});
 
-	describe("default value calculation", async () => {
+	describe("default value calculation", () => {
 		let model: Model;
 		let TestEntity: Type;
 		beforeEach(async () => {

--- a/src/format.ts
+++ b/src/format.ts
@@ -414,10 +414,11 @@ export function createFormat<T>(model: Model, type: any, format: string): Format
 				}
 			},
 			convertBack: function (str: string): boolean | FormatError {
-				if (str.toLowerCase() === trueFormat.toLowerCase()) {
+				str = str.trim();
+				if (str.toLowerCase() === trueFormat.trim().toLowerCase()) {
 					return true;
 				}
-				else if (str.toLowerCase() === falseFormat.toLowerCase()) {
+				else if (str.toLowerCase() === falseFormat.trim().toLowerCase()) {
 					return false;
 				}
 				else {

--- a/src/format.ts
+++ b/src/format.ts
@@ -402,6 +402,15 @@ export function createFormat<T>(model: Model, type: any, format: string): Format
 			nullFormat = formats.length > 2 ? formats[2] : "";
 		}
 
+		/**
+		 * Determines if the given string matches the given format option
+		 * @param str The text to check
+		 * @param formatValue The true or false format option
+		 */
+		const isFormatMatch = (str, formatValue) => {
+			return str.trim().toLowerCase() === formatValue.trim().toLowerCase();
+		};
+
 		return Format.create<boolean>(model, {
 			specifier: format,
 			convert: function (val: boolean): string {
@@ -416,15 +425,12 @@ export function createFormat<T>(model: Model, type: any, format: string): Format
 				}
 			},
 			convertBack: function (str: string): boolean | FormatError {
-				if (str.toLowerCase() === trueFormat.trim().toLowerCase()) {
+				if (isFormatMatch(str, trueFormat))
 					return true;
-				}
-				else if (str.toLowerCase() === falseFormat.trim().toLowerCase()) {
+				else if (isFormatMatch(str, falseFormat))
 					return false;
-				}
-				else {
+				else
 					return null;
-				}
 			}
 		}) as any;
 	}

--- a/src/format.ts
+++ b/src/format.ts
@@ -64,7 +64,9 @@ export abstract class Format<T> {
 		}
 
 		if (typeof text === "string") {
-			if (text.trim().length === 0) {
+			text = text.trim();
+
+			if (text.length === 0) {
 				return null;
 			}
 		}
@@ -414,7 +416,6 @@ export function createFormat<T>(model: Model, type: any, format: string): Format
 				}
 			},
 			convertBack: function (str: string): boolean | FormatError {
-				str = str.trim();
 				if (str.toLowerCase() === trueFormat.trim().toLowerCase()) {
 					return true;
 				}

--- a/src/format.ts
+++ b/src/format.ts
@@ -64,9 +64,7 @@ export abstract class Format<T> {
 		}
 
 		if (typeof text === "string") {
-			text = text.trim();
-
-			if (text.length === 0) {
+			if (text.trim().length === 0) {
 				return null;
 			}
 		}

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -90,6 +90,68 @@ describe("format", () => {
 		expect(form.toString("[Table]")).toBe("Text2, Text2");
 	});
 
+	describe("Date", () => {
+		let model: Model;
+		beforeEach(() => {
+			CultureInfo.setup();
+			model = new Model({
+				$culture: "en-US",
+				"Form": {
+					DateTimeField: {
+						label: "Date / Time",
+						type: Date,
+						format: " M/d/yyyy h:mm tt "
+					},
+					DateField: {
+						label: "Date",
+						type: Date,
+						format: " M/d/yyyy "
+					},
+					TimeField: {
+						label: "Time",
+						type: Date,
+						format: " h:mm tt "
+					}
+				}
+			});
+		});
+		test("can be formatted as a date and time", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.DateTimeField = new Date(2021, 11, 10, 16, 38);
+			expect(form.toString("[DateTimeField]")).toBe(" 12/10/2021 4:38 PM ");
+		});
+		test("can be parsed as a date and time", async () => {
+			let form = await model.types.Form.create({}) as any;
+			let result = model.types.Form.getProperty("DateTimeField").format.convertBack(" 12/10/2021 4:38 PM ");
+			expect(result.constructor).toBe(Date);
+			form.DateTimeField = result;
+			expect(form.DateTimeField).toEqual(new Date(2021, 11, 10, 16, 38));
+		});
+		test("can be formatted as a date", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.DateField = new Date(2021, 11, 10);
+			expect(form.toString("[DateField]")).toBe(" 12/10/2021 ");
+		});
+		test("can be parsed as a date", async () => {
+			let form = await model.types.Form.create({}) as any;
+			var result = model.types.Form.getProperty("DateField").format.convertBack(" 12/10/2021 ");
+			expect(result.constructor).toBe(Date);
+			form.DateField = result;
+			expect(form.DateField).toEqual(new Date(2021, 11, 10));
+		});
+		test("can be formatted as a time", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.TimeField = new Date(1970, 0, 1, 16, 38);
+			expect(form.toString("[TimeField]")).toBe(" 4:38 PM ");
+		});
+		test("can be parsed as a time", async () => {
+			let form = await model.types.Form.create({}) as any;
+			let result = model.types.Form.getProperty("TimeField").format.convertBack(" 4:38 PM ");
+			form.TimeField = result;
+			expect(form.TimeField).toEqual(new Date(1970, 0, 1, 16, 38));
+		});
+	});
+
 	describe("Number", () => {
 		let model: Model;
 		beforeEach(() => {

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -150,33 +150,29 @@ describe("format", () => {
 		});
 	});
 
-	test("boolean values are formatted using a two-part boolean property format", async () => {
-		var model = new Model({
-			"Form": {
-				BooleanField: {
-					label: "Boolean",
-					type: Boolean,
-					format: "Yes ;No ",
-					default: false
+	describe("Boolean", () => {
+		let model: Model;
+		beforeEach(() => {
+			CultureInfo.setup();
+			model = new Model({
+				"Form": {
+					BooleanField: {
+						label: "Boolean",
+						type: Boolean,
+						format: "Yes ;No ",
+						default: false
+					}
 				}
-			}
+			});
 		});
-		let form = await model.types.Form.create({}) as any;
-		expect(form.toString("[BooleanField]")).toBe("No ");
-	});
+		test("values are formatted using a two-part boolean property format", async () => {
+			let form = await model.types.Form.create({}) as any;
+			expect(form.toString("[BooleanField]")).toBe("No ");
+		});
 
-	test("boolean values can be parsed using the two-part boolean property format", async () => {
-		var model = new Model({
-			"Form": {
-				BooleanField: {
-					label: "Boolean",
-					type: Boolean,
-					format: "Yes ;No ",
-					default: false
-				}
-			}
+		test("boolean values can be parsed using the two-part boolean property format", async () => {
+			let prop = model.types.Form.getProperty("BooleanField");
+			expect(prop.format.convertBack("Yes ")).toBe(true);
 		});
-		let prop = model.types.Form.getProperty("BooleanField");
-		expect(prop.format.convertBack("Yes ")).toBe(true);
 	});
 });

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -88,4 +88,34 @@ describe("format", () => {
 		let form = await model.types.Form.create({}) as any;
 		expect(form.toString("[Table]")).toBe("Text2, Text2");
 	});
+
+	test("boolean values are formatted using a two-part boolean property format", async () => {
+		var model = new Model({
+			"Form": {
+				BooleanField: {
+					label: "Boolean",
+					type: Boolean,
+					format: "Yes ;No ",
+					default: false
+				}
+			}
+		});
+		let form = await model.types.Form.create({}) as any;
+		expect(form.toString("[BooleanField]")).toBe("No ");
+	});
+
+	test("boolean values can be parsed using the two-part boolean property format", async () => {
+		var model = new Model({
+			"Form": {
+				BooleanField: {
+					label: "Boolean",
+					type: Boolean,
+					format: "Yes ;No ",
+					default: false
+				}
+			}
+		});
+		let prop = model.types.Form.getProperty("BooleanField");
+		expect(prop.format.convertBack("Yes ")).toBe(true);
+	});
 });

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -56,8 +56,8 @@ describe("format", () => {
 		});
 		let form = await model.types.Form.create({}) as any;
 		form.Text = "label1";
-		var val = model.types.Form.jstype.$Number.format.convertBack("test") as FormatError;
-		var error = val.createCondition(form, model.types.Form.jstype.$Number);
+		var val = model.types.Form.getProperty("Number").format.convertBack("test") as FormatError;
+		var error = val.createCondition(form, model.types.Form.getProperty("Number"));
 
 		expect(error.message).toBe("label1 must be formatted as #,###.");
 		form.Text = "label2";

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -255,7 +255,7 @@ describe("format", () => {
 
 		test("boolean values can be parsed using the two-part boolean property format", async () => {
 			let prop = model.types.Form.getProperty("BooleanField");
-			expect(prop.format.convertBack("Yes ")).toBe(true);
+			expect(prop.format.convertBack(" Yes ")).toBe(true);
 		});
 	});
 });

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -115,6 +115,13 @@ describe("format", () => {
 				}
 			});
 		});
+		test("parses null or whitespace as null", async () => {
+			let form = await model.types.Form.create({}) as any;
+			let result = model.types.Form.getProperty("DateTimeField").format.convertBack(" ");
+			expect(result).toBeNull();
+			form.DateTimeField = result;
+			expect(form.DateTimeField).toBeNull();
+		});
 		test("can be formatted as a date and time", async () => {
 			let form = await model.types.Form.create({}) as any;
 			form.DateTimeField = new Date(2021, 11, 10, 16, 38);
@@ -177,6 +184,13 @@ describe("format", () => {
 				}
 			});
 		});
+		test("parses null or whitespace as null", async () => {
+			let form = await model.types.Form.create({}) as any;
+			let result = model.types.Form.getProperty("IntegerField").format.convertBack(" ");
+			expect(result).toBeNull();
+			form.IntegerField = result;
+			expect(form.IntegerField).toBeNull();
+		});
 		test("can be formatted as an integer", async () => {
 			let form = await model.types.Form.create({}) as any;
 			form.IntegerField = 3.14;
@@ -226,6 +240,13 @@ describe("format", () => {
 					}
 				}
 			});
+		});
+		test("parses null or whitespace as null", async () => {
+			let form = await model.types.Form.create({}) as any;
+			let result = model.types.Form.getProperty("BooleanField").format.convertBack(" ");
+			expect(result).toBeNull();
+			form.BooleanField = result;
+			expect(form.BooleanField).toBeNull();
 		});
 		test("values are formatted using a two-part boolean property format", async () => {
 			let form = await model.types.Form.create({}) as any;

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -1,4 +1,5 @@
 import { FormatError } from "./format-error";
+import { CultureInfo } from "./globalization";
 import { Model } from "./model";
 import "./resource-en";
 
@@ -87,6 +88,66 @@ describe("format", () => {
 		});
 		let form = await model.types.Form.create({}) as any;
 		expect(form.toString("[Table]")).toBe("Text2, Text2");
+	});
+
+	describe("Number", () => {
+		let model: Model;
+		beforeEach(() => {
+			CultureInfo.setup();
+			model = new Model({
+				$culture: "en-US",
+				"Form": {
+					IntegerField: {
+						label: "Integer",
+						type: Number,
+						format: "N0"
+					},
+					DecimalField: {
+						label: "Decimal",
+						type: Number,
+						format: "N2"
+					},
+					PercentageField: {
+						label: "Percentage",
+						type: Number,
+						format: "P1"
+					}
+				}
+			});
+		});
+		test("can be formatted as an integer", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.IntegerField = 3.14;
+			expect(form.IntegerField).toBe(3.14);
+			expect(form.toString("[IntegerField]")).toBe("3");
+		});
+		test("can be parsed as an integer", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.IntegerField = model.types.Form.getProperty("IntegerField").format.convertBack(" 3 ");
+			expect(form.IntegerField).toBe(3);
+		});
+		test("can be formatted as a decimal", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.DecimalField = 3;
+			expect(form.DecimalField).toBe(3);
+			expect(form.toString("[DecimalField]")).toBe("3.00");
+		});
+		test("can be parsed as a decimal", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.DecimalField = model.types.Form.getProperty("DecimalField").format.convertBack(" 3.14 ");
+			expect(form.DecimalField).toBe(3.14);
+		});
+		test("can be formatted as a percentage", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.PercentageField = 0.2;
+			expect(form.PercentageField).toBe(0.2);
+			expect(form.toString("[PercentageField]")).toBe("20.0 %");
+		});
+		test("can be parsed as a percentage", async () => {
+			let form = await model.types.Form.create({}) as any;
+			form.PercentageField = model.types.Form.getProperty("PercentageField").format.convertBack(" 20 % ");
+			expect(form.PercentageField).toBe(0.20);
+		});
 	});
 
 	test("boolean values are formatted using a two-part boolean property format", async () => {

--- a/src/format.unit.ts
+++ b/src/format.unit.ts
@@ -100,17 +100,17 @@ describe("format", () => {
 					DateTimeField: {
 						label: "Date / Time",
 						type: Date,
-						format: " M/d/yyyy h:mm tt "
+						format: "M/d/yyyy h:mm tt"
 					},
 					DateField: {
 						label: "Date",
 						type: Date,
-						format: " M/d/yyyy "
+						format: "M/d/yyyy"
 					},
 					TimeField: {
 						label: "Time",
 						type: Date,
-						format: " h:mm tt "
+						format: "h:mm tt"
 					}
 				}
 			});
@@ -125,7 +125,7 @@ describe("format", () => {
 		test("can be formatted as a date and time", async () => {
 			let form = await model.types.Form.create({}) as any;
 			form.DateTimeField = new Date(2021, 11, 10, 16, 38);
-			expect(form.toString("[DateTimeField]")).toBe(" 12/10/2021 4:38 PM ");
+			expect(form.toString("[DateTimeField]")).toBe("12/10/2021 4:38 PM");
 		});
 		test("can be parsed as a date and time", async () => {
 			let form = await model.types.Form.create({}) as any;
@@ -137,7 +137,7 @@ describe("format", () => {
 		test("can be formatted as a date", async () => {
 			let form = await model.types.Form.create({}) as any;
 			form.DateField = new Date(2021, 11, 10);
-			expect(form.toString("[DateField]")).toBe(" 12/10/2021 ");
+			expect(form.toString("[DateField]")).toBe("12/10/2021");
 		});
 		test("can be parsed as a date", async () => {
 			let form = await model.types.Form.create({}) as any;
@@ -149,7 +149,7 @@ describe("format", () => {
 		test("can be formatted as a time", async () => {
 			let form = await model.types.Form.create({}) as any;
 			form.TimeField = new Date(1970, 0, 1, 16, 38);
-			expect(form.toString("[TimeField]")).toBe(" 4:38 PM ");
+			expect(form.toString("[TimeField]")).toBe("4:38 PM");
 		});
 		test("can be parsed as a time", async () => {
 			let form = await model.types.Form.create({}) as any;

--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -318,7 +318,6 @@ export function parseDate(value: string, cultureInfo: CultureInfo, formats?: str
 }
 
 function parseDateExact(value: string, format: string, cultureInfo: CultureInfo): Date {
-	value = value.trim();
 	var dtf = cultureInfo.dateTimeFormat;
 	var parseInfo = getDateParseRegExp(dtf, format);
 	var match = new RegExp(parseInfo.regExp).exec(value);

--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -318,6 +318,7 @@ export function parseDate(value: string, cultureInfo: CultureInfo, formats?: str
 }
 
 function parseDateExact(value: string, format: string, cultureInfo: CultureInfo): Date {
+	value = value.trim();
 	var dtf = cultureInfo.dateTimeFormat;
 	var parseInfo = getDateParseRegExp(dtf, format);
 	var match = new RegExp(parseInfo.regExp).exec(value);

--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -961,19 +961,8 @@ export function formatNumber(number: number, format: string, cultureInfo: Cultur
 
 	let num: number | string = Math.abs(number);
 
-	let prefix = "";
-	let suffix = "";
-
 	if (!format)
 		format = "D";
-	else {
-		const whitespaceMatch = /^(\s*)([^\s].*[^\s])(\s*)$/.exec(format);
-		if (whitespaceMatch) {
-			prefix = whitespaceMatch[1];
-			format = whitespaceMatch[2];
-			suffix = whitespaceMatch[3];
-		}
-	}
 
 	var precision = -1;
 	if (format.length > 1) precision = parseInt(format.slice(1), 10);
@@ -1047,7 +1036,7 @@ export function formatNumber(number: number, format: string, cultureInfo: Cultur
 		}
 	}
 
-	return prefix + ret + suffix;
+	return ret;
 }
 
 function toUpper(value: string) {

--- a/src/globalization.ts
+++ b/src/globalization.ts
@@ -950,6 +950,7 @@ export function formatNumber(number: number, format: string, cultureInfo: Cultur
 			return number.toString();
 		}
 	}
+
 	var _percentPositivePattern = ["n %", "n%", "%n" ];
 	var _percentNegativePattern = ["-n %", "-n%", "-%n"];
 	var _numberNegativePattern = ["(n)", "-n", "- n", "n-", "n -"];
@@ -960,8 +961,19 @@ export function formatNumber(number: number, format: string, cultureInfo: Cultur
 
 	let num: number | string = Math.abs(number);
 
+	let prefix = "";
+	let suffix = "";
+
 	if (!format)
 		format = "D";
+	else {
+		const whitespaceMatch = /^(\s*)([^\s].*[^\s])(\s*)$/.exec(format);
+		if (whitespaceMatch) {
+			prefix = whitespaceMatch[1];
+			format = whitespaceMatch[2];
+			suffix = whitespaceMatch[3];
+		}
+	}
 
 	var precision = -1;
 	if (format.length > 1) precision = parseInt(format.slice(1), 10);
@@ -1035,7 +1047,7 @@ export function formatNumber(number: number, format: string, cultureInfo: Cultur
 		}
 	}
 
-	return ret;
+	return prefix + ret + suffix;
 }
 
 function toUpper(value: string) {

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -75,8 +75,11 @@ describe("globalize", function () {
 			expect(formatNumber({ x: 5 }, "n1", CultureInfo.CurrentCulture)).toBeNull();
 		});
 
+		// TODO: Technically this behavior is not consistent with .NET number formatting behavior
 		test("whitespace is preserved", () => {
-			expect(formatNumber(3.14, " n1 ", CultureInfo.CurrentCulture)).toBe(" 3.1 ");
+			expect(() => {
+				return formatNumber(3.14, " n1 ", CultureInfo.CurrentCulture);
+			}).toThrowError("Sys.FormatException: Format specifier was invalid.");
 		});
 	});
 

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -23,6 +23,9 @@ describe("globalize", function () {
 		test("formatDate(date, 't', 'CurrentCulture')", () => {
 			expect(formatDate(new Date(2019, 1, 13, 11, 26, 34), "t", CultureInfo.CurrentCulture)).toBe("11:26 AM");
 		});
+		test("whitespace is preserved", () => {
+			expect(formatDate(new Date(2019, 1, 13, 11, 26, 34), " yyyy - MM - dd ", CultureInfo.CurrentCulture)).toBe(" 2019 - 02 - 13 ");
+		});
 	});
 
 	describe("parseDate", function () {
@@ -30,11 +33,9 @@ describe("globalize", function () {
 			expect(+parseDate("2/13/2019", CultureInfo.CurrentCulture)).toBe(+(new Date(2019, 1, 13)));
 		});
 		test("parseDate('####-##-##', 'CurrentCulture')", () => {
-			debugger;
 			expect(parseDate("2019-02-13", CultureInfo.CurrentCulture)).toBeNull();
 		});
 		test("parseDate('####-##-##', 'CurrentCulture', ['yyyy-MM-dd'])", () => {
-			debugger;
 			expect(+parseDate("2019-02-13", CultureInfo.CurrentCulture, ["yyyy-MM-dd"])).toBe(+(new Date(2019, 1, 13)));
 		});
 		test("parseDate('M/dd/yyyy hh:mm AM', 'CurrentCulture', 'g')", () => {
@@ -45,6 +46,9 @@ describe("globalize", function () {
 		});
 		test("parseDate('hh:mm AM', 'CurrentCulture', 't')", () => {
 			expect(+parseDate("11:26 AM", CultureInfo.CurrentCulture, "t")).toBe(+(new Date(1970, 0, 1, 11, 26)));
+		});
+		test("parseDate('####-##-##', 'CurrentCulture', [' yyyy - MM - dd '])", () => {
+			expect(+parseDate(" 2019 - 02 - 13 ", CultureInfo.CurrentCulture, [" yyyy - MM - dd "])).toBe(+(new Date(2019, 1, 13)));
 		});
 	});
 
@@ -70,6 +74,10 @@ describe("globalize", function () {
 		test("returns null given object", () => {
 			expect(formatNumber({ x: 5 }, "n1", CultureInfo.CurrentCulture)).toBeNull();
 		});
+
+		test("whitespace is preserved", () => {
+			expect(formatNumber(3.14, " n1 ", CultureInfo.CurrentCulture)).toBe(" 3.1 ");
+		});
 	});
 
 	describe("parseNumber", () => {
@@ -81,6 +89,9 @@ describe("globalize", function () {
 		});
 		test("parseNumber('#')", () => {
 			expect(parseNumber("3", "Number", CultureInfo.CurrentCulture)).toBe(3);
+		});
+		test("parseNumber(' # ')", () => {
+			expect(parseNumber(" 3 ", "Number", CultureInfo.CurrentCulture)).toBe(3);
 		});
 	});
 });

--- a/src/globalization.unit.js
+++ b/src/globalization.unit.js
@@ -47,8 +47,8 @@ describe("globalize", function () {
 		test("parseDate('hh:mm AM', 'CurrentCulture', 't')", () => {
 			expect(+parseDate("11:26 AM", CultureInfo.CurrentCulture, "t")).toBe(+(new Date(1970, 0, 1, 11, 26)));
 		});
-		test("parseDate('####-##-##', 'CurrentCulture', [' yyyy - MM - dd '])", () => {
-			expect(+parseDate(" 2019 - 02 - 13 ", CultureInfo.CurrentCulture, [" yyyy - MM - dd "])).toBe(+(new Date(2019, 1, 13)));
+		test("parseDate('####-##-##', 'CurrentCulture', ['yyyy-MM-dd'])", () => {
+			expect(+parseDate(" 2019-02-13 ", CultureInfo.CurrentCulture, ["yyyy-MM-dd"])).toBe(+(new Date(2019, 1, 13)));
 		});
 	});
 


### PR DESCRIPTION
- Trim both input and true/false values in the boolean formatter
- Add unit tests for Date/Number/Boolean custom format specifiers
- Add unit tests for low-level date and number formatting and parsing