### PR TITLE
Extending type creates new property if existing property types are different

### DIFF
--- a/src/type.ts
+++ b/src/type.ts
@@ -455,7 +455,7 @@ export class Type {
 
 					// Add Property
 					if (!property
-						|| (member.type && !isValueType(member.type) && !isValueType(property.propertyType) && property.propertyType.meta.fullName !== member.type)
+						|| (member.type && isEntityType(property.propertyType) && property.propertyType.meta.fullName !== member.type)
 						|| (member.type && isValueType(member.type) && isValueType(property.propertyType) && property.propertyType !== member.type)) {
 						// Type & IsList
 						let isList = false;

--- a/src/type.ts
+++ b/src/type.ts
@@ -454,7 +454,7 @@ export class Type {
 					let property = this.getProperty(name);
 
 					// Add Property
-					if (!property || property.containingType !== member.type) {
+					if (!property || (member.type && property.propertyType !== member.type)) {
 						// Type & IsList
 						let isList = false;
 						if (typeof (member.type) === "string") {

--- a/src/type.ts
+++ b/src/type.ts
@@ -454,7 +454,7 @@ export class Type {
 					let property = this.getProperty(name);
 
 					// Add Property
-					if (!property) {
+					if (!property || property.containingType !== member.type) {
 						// Type & IsList
 						let isList = false;
 						if (typeof (member.type) === "string") {

--- a/src/type.ts
+++ b/src/type.ts
@@ -335,15 +335,15 @@ export class Type {
 	}
 
 	get properties(): Property[] {
-		let propertiesArray: Property[] = Object.values(this.__properties__);
+		let propertiesObject: { [name: string]: Property } = this.__properties__;
 		for (var type: Type = this.baseType; type != null; type = type.baseType) {
 			for (var propertyName in type.__properties__) {
-				if (!this.__properties__.hasOwnProperty(propertyName)) {
-					propertiesArray.push(type.__properties__[propertyName]);
+				if (!propertiesObject.hasOwnProperty(propertyName)) {
+					propertiesObject[propertyName] = type.__properties__[propertyName];
 				}
 			}
 		}
-		return propertiesArray;
+		return Object.values(propertiesObject);
 	}
 
 	addRule(optionsOrFunction: ((this: Entity) => void) | RuleOptions): Rule {

--- a/src/type.ts
+++ b/src/type.ts
@@ -454,7 +454,9 @@ export class Type {
 					let property = this.getProperty(name);
 
 					// Add Property
-					if (!property || (member.type && property.propertyType !== member.type)) {
+					if (!property
+						|| (member.type && !isValueType(member.type) && !isValueType(property.propertyType) && property.propertyType.meta.fullName !== member.type)
+						|| (member.type && isValueType(member.type) && isValueType(property.propertyType) && property.propertyType !== member.type)) {
 						// Type & IsList
 						let isList = false;
 						if (typeof (member.type) === "string") {

--- a/src/type.ts
+++ b/src/type.ts
@@ -335,10 +335,10 @@ export class Type {
 	}
 
 	get properties(): Property[] {
-		let propertiesArray: Property[] = [];
-		for (var type: Type = this; type != null; type = type.baseType) {
+		let propertiesArray: Property[] = Object.values(this.__properties__);
+		for (var type: Type = this.baseType; type != null; type = type.baseType) {
 			for (var propertyName in type.__properties__) {
-				if (type.__properties__.hasOwnProperty(propertyName)) {
+				if (!this.__properties__.hasOwnProperty(propertyName)) {
 					propertiesArray.push(type.__properties__[propertyName]);
 				}
 			}

--- a/src/type.ts
+++ b/src/type.ts
@@ -335,7 +335,7 @@ export class Type {
 	}
 
 	get properties(): Property[] {
-		let propertiesObject: { [name: string]: Property } = this.__properties__;
+		let propertiesObject: { [name: string]: Property } = { ...this.__properties__ };
 		for (var type: Type = this.baseType; type != null; type = type.baseType) {
 			for (var propertyName in type.__properties__) {
 				if (!propertiesObject.hasOwnProperty(propertyName)) {

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -107,6 +107,40 @@ describe("Type", () => {
 			await model.types.Entity.create({ Id: "x" });
 			expect(() => model.types.Entity.create({ Id: "x" })).toThrow(/already exists/);
 		});
+
+		it("Extended properties have the correct type", async () => {
+			const model = new Model({
+				"Root.Leaf": {
+					LeafId: {
+						type: Number
+					}
+				},
+				Root: {
+					Id: {
+						type: Number
+					},
+					Leaf: {
+						type: "Root.Leaf"
+					}
+				},
+				"Branch.Leaf": {
+					$extends: "Root.Leaf",
+					LeafId: {
+						type: String
+					}
+				},
+				Branch: {
+					$extends: "Root",
+					Leaf: {
+						type: "Branch.Leaf"
+					}
+				}
+			});
+			const branch = await model.types.Branch.create({ Id: 1, Leaf: { LeafId: "1" } }) as any;
+			expect(branch.meta.type.fullName).toBe("Branch");
+			expect(branch.Leaf.meta.type.fullName).toBe("Branch.Leaf");
+			expect(branch.Leaf.LeafId).toBe("1");
+		});
 	});
 
 	describe("createIfNotExists", () => {

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -44,7 +44,6 @@ describe("Type", () => {
 
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			let parent = await model.types.Parent.create({ Child: "1" });
-			console.log("test after await");
 			expect((parent as any).Child.Sibling.Name).toBe("Sibling Name");
 		});
 
@@ -140,6 +139,7 @@ describe("Type", () => {
 			expect(branch.meta.type.fullName).toBe("Branch");
 			expect(branch.Leaf.meta.type.fullName).toBe("Branch.Leaf");
 			expect(branch.Leaf.LeafId).toBe("1");
+			expect(branch.serialize()).toStrictEqual({ Id: 1, Leaf: { LeafId: "1" } });
 		});
 	});
 


### PR DESCRIPTION
When extending a type by adding a property and the type already has an existing property we were just extending that existing property this causes issues if the new property has a different type than the existing property. To fix it if the types of the new property and existing property are different create a new property instead of extending the existing one.