### PR TITLE
Remove excess items when updating an array with an array

### DIFF
--- a/src/entity.ts
+++ b/src/entity.ts
@@ -234,7 +234,7 @@ export class Entity {
 			if (prop.isList && Array.isArray(state) && Array.isArray(currentValue)) {
 				if (!state.length)
 					currentValue.splice(0);
-				else
+				else {
 					state.forEach((s, idx) => {
 						if (!(s instanceof ChildEntity))
 							s = this.serializer.deserialize(this, s, prop, this._context, false);
@@ -265,6 +265,8 @@ export class Entity {
 						else
 							currentValue.push(Entity.createOrUpdate(ChildEntity.meta, s, this._context));
 					});
+					currentValue.splice(state.length);
+				}
 			}
 			else if (state instanceof ChildEntity)
 				value = state;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -265,6 +265,7 @@ export class Entity {
 						else
 							currentValue.push(Entity.createOrUpdate(ChildEntity.meta, s, this._context));
 					});
+					// Remove excess items from the list
 					currentValue.splice(state.length);
 				}
 			}

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -384,6 +384,32 @@ describe("Entity", () => {
 	});
 
 	describe("list", () => {
+		const PersonWithSkillsModel = {
+			Skill: {
+				Name: String,
+				Proficiency: {
+					default() { return null; },
+					type: Number
+				}
+			},
+			Person: {
+				Skills: {
+					Id: { identifier: true, type: String },
+					type: "Skill[]",
+					default: () => [{
+						Id: 1,
+						Name: "Climbing",
+						Proficiency: 4
+					},
+					{
+						Id: 2,
+						Name: "Eating",
+						Proficiency: 4
+					}]
+				}
+			}
+		};
+
 		it("can add/remove primitive items", () => {
 			const movie = new Types.Movie(Alien) as any;
 			const horror = "horror";
@@ -419,32 +445,20 @@ describe("Entity", () => {
 		});
 
 		it("can set an empty list", async () => {
-			const model = new Model({
-				Skill: {
-					Name: String,
-					Proficiency: {
-						default() { return null; },
-						type: Number
-					}
-				},
-				Person: {
-					Skills: {
-						type: "Skill[]",
-						default: () => [{
-							Name: "Climbing",
-							Proficiency: 4
-						},
-						{
-							Name: "Eating",
-							Proficiency: 4
-						}]
-					}
-				}
-			});
+			const model = new Model(PersonWithSkillsModel);
 			const instance = await model.types.Person.create({}) as any;
 			expect(instance.Skills.length).toBe(2);
 			instance.update({ Skills: [] });
 			expect(instance.Skills.length).toBe(0);
+		});
+
+		it("Updating a list with an array with less items does not leave extra items in the array", async () => {
+			const model = new Model(PersonWithSkillsModel);
+			const instance = await model.types.Person.create({}) as any;
+			const skillInstance = await model.types.Skill.create({ Name: "Surfing" }) as any;
+			expect(instance.Skills.length).toBe(2);
+			instance.update({ Skills: [skillInstance] }, null, true);
+			expect(instance.Skills.length).toBe(1);
 		});
 	});
 


### PR DESCRIPTION
When updating an array with an array with less items it leaves the excess items in the array

Example
current array: `['1', '2', '3']`
call update with: `['a', 'b']`
updated array result: `['a', 'b', '3']`

After this change the updated array result would be  `['a', 'b']`.