### PR TITLE
rely on PropertyGet event instead of InitNew for default calculations

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-options=--openssl-legacy-provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- Do not run default calculation rules until property access
+### Fixed
+- Allow default calculations to run on properties initialized to default value for type
 ## [0.8.30] - 2022-06-09
 ### Fixed
 - Remove excess items when updating an array with an array

--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -32,11 +32,6 @@ export class CalculatedPropertyRule extends Rule {
 			if (options.property) {
 				property = typeof options.property === "string" ? rootType.getProperty(options.property) as Property : options.property as Property;
 
-				if (options.isDefaultValue) {
-					// Ensure the default value rule runs on init of a new instance
-					(options as RuleInvocationOptions).onInitNew = true;
-				}
-
 				// indicate that the rule is responsible for returning the value of the calculated property
 				options.returns = [property];
 			}

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -63,6 +63,17 @@ describe("CalculateRule", () => {
 					Name2: {
 						type: String,
 						default: "John Doe"
+					},
+					Num: {
+						type: Number,
+						default: 5
+					},
+					Num2: {
+						type: Number,
+						default: {
+							dependsOn: "Num",
+							function() { return this.get("Num"); }
+						}
 					}
 				}
 			});
@@ -89,6 +100,18 @@ describe("CalculateRule", () => {
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBeNull();
+			});
+
+			describe("number property", () => {
+				it("is defaulted", async () => {
+					const entity = await TestEntity.create({});
+					expect(entity["Num"]).toBe(5);
+				});
+
+				it("is defaulted based on other defaulted property", async () => {
+					const entity = await TestEntity.create({});
+					expect(entity["Num2"]).toBe(5);
+				});
 			});
 		});
 

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -396,16 +396,18 @@ describe("Entity", () => {
 				Skills: {
 					Id: { identifier: true, type: String },
 					type: "Skill[]",
-					default: () => [{
-						Id: 1,
-						Name: "Climbing",
-						Proficiency: 4
-					},
-					{
-						Id: 2,
-						Name: "Eating",
-						Proficiency: 4
-					}]
+					default() {
+						return [{
+							Id: 1,
+							Name: "Climbing",
+							Proficiency: 4
+						},
+						{
+							Id: 2,
+							Name: "Eating",
+							Proficiency: 4
+						}];
+					}
 				}
 			}
 		};

--- a/src/property.ts
+++ b/src/property.ts
@@ -926,7 +926,7 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 			Property$init(property, obj, Property$getInitialValue(property));
 
 			const underlyingValue = obj.__fields__[property.name];
-			// Mark the property as pending initialization if it still has no underlying value, or is the property's default, to allow default calculation rules to run for it
+			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it
 			if (underlyingValue === property.defaultValue || (property.isList && underlyingValue.length === 0))
 				Property$pendingInit(obj, property, true);
 		}

--- a/src/property.ts
+++ b/src/property.ts
@@ -927,7 +927,7 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 			const underlyingValue = obj.__fields__[property.name];
 			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it
-			if (underlyingValue === property.defaultValue || (property.isList && underlyingValue.length === 0))
+			if (underlyingValue === property.defaultValue || (property.isList && Array.isArray(underlyingValue) && underlyingValue.length === 0))
 				Property$pendingInit(obj, property, true);
 		}
 	}

--- a/src/property.ts
+++ b/src/property.ts
@@ -925,8 +925,9 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 		if (!property.isCalculated) {
 			Property$init(property, obj, Property$getInitialValue(property));
 
-			// Mark the property as pending initialization if it still has no underlying value to allow default calculation rules to run for it
-			if (obj.__fields__[property.name] === null)
+			const underlyingValue = obj.__fields__[property.name];
+			// Mark the property as pending initialization if it still has no underlying value, or is the property's default, to allow default calculation rules to run for it
+			if (underlyingValue === property.defaultValue || (property.isList && underlyingValue.length === 0))
 				Property$pendingInit(obj, property, true);
 		}
 	}


### PR DESCRIPTION
This fixes an issue where default property calculations referencing properties that are not listed as predicates (`dependsOn`) would run before said properties had been initialized. Since the defaulted property did not list the dependent property as a predicate, the default would not be recalculated when the other property was eventually set, after entity initialization.

This is not _strictly_ a bug, since property calculations shouldn't rely on properties without listing them as dependencies, but it does support a specific scenario in the product, and does not seem to have a downside.