### PR TITLE
Fix for default value calculation based on a calculated property

### DIFF
--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -89,10 +89,8 @@ export class CalculatedPropertyRule extends Rule {
 				// run the calculation and throw away the result.
 				const initialValue = args.entity.__fields__[this.property.name];
 				if (initialValue !== undefined) {
-					const calculateFn = this.ensureCalculateFn();
-
 					try {
-						calculateFn.call(args.entity);
+						this.calculateFn.call(args.entity);
 					}
 					catch (e) {
 					}
@@ -101,7 +99,7 @@ export class CalculatedPropertyRule extends Rule {
 		}
 	}
 
-	ensureCalculateFn() {
+	get calculateFn() {
 		let calculateFn: (this: Entity) => any;
 
 		// Convert string functions into compiled functions on first execution
@@ -119,16 +117,14 @@ export class CalculatedPropertyRule extends Rule {
 	}
 
 	execute(obj: Entity): void {
-		const calculateFn = this.ensureCalculateFn();
-
 		// Calculate the new property value
 		var newValue;
 		if (this.defaultIfError === undefined) {
-			newValue = calculateFn.call(obj);
+			newValue = this.calculateFn.call(obj);
 		}
 		else {
 			try {
-				newValue = calculateFn.call(obj);
+				newValue = this.calculateFn.call(obj);
 			}
 			catch (e) {
 				newValue = this.defaultIfError;

--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -74,11 +74,17 @@ export class CalculatedPropertyRule extends Rule {
 	register() {
 		super.register();
 
-		// TODO: Restrict this to default values or apply to all calculation?
-		// Why is this here?
 		if (this.isDefaultValue) {
+			// Ensure that a default value rule will run if a calculation that it depends on is changed.
+			// A property with a default value rule may have a persisted value, in which case it will
+			// not run unless one of its predicates fires a change event. A calculation will not fire
+			// a change event the first time it runs if it didn't previously have a value, which may
+			// be the case for existing instances if the calculation is never accessed (ex: a hidden field).
+			// So, in order to ensure that the default rule's calculated predicates fire a change event,
+			// we must ensure that the calculation is accessed when the object is initialized.
 			this.rootType.initExisting.subscribe((args) => {
-				// If property is initialized, run the calculation and throw away the result
+				// If the property is initialized (i.e. it has an initial persisted value),
+				// run the calculation and throw away the result.
 				const initialValue = args.entity.__fields__[this.property.name];
 				if (initialValue !== undefined) {
 					const calculateFn = this.ensureCalculateFn();

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -74,6 +74,21 @@ describe("CalculateRule", () => {
 							dependsOn: "Num",
 							function() { return this.get("Num"); }
 						}
+					},
+					Text: String,
+					CalculatedText: {
+						type: String,
+						get: {
+							dependsOn: "Text",
+							function() { return this.get("Text"); }
+						}
+					},
+					DefaultedText: {
+						type: String,
+						default: {
+							dependsOn: "CalculatedText",
+							function() { return this.get("CalculatedText"); }
+						}
 					}
 				}
 			});
@@ -142,6 +157,15 @@ describe("CalculateRule", () => {
 
 				expect(entity["Name2"]).toBe("John Doe");
 				expect(entity["Name"]).toBeNull();
+			});
+
+			it("updates when a dependent calculation changes", async () => {
+				const entity = await TestEntity.create({ Id: "1", Text: null, DefaultedText: null });
+
+				entity.update({ Text: "abc" });
+
+				expect(entity["CalculatedText"]).toBe("abc");
+				expect(entity["DefaultedText"]).toBe("abc");
 			});
 		});
 	});


### PR DESCRIPTION
**Problem**:
In some cases, a default value rule may not run for an existing persisted entity when one of the rule's predicates calculates for the first time.

Calculations vs. Defaults:
Calculations generally run on first access in order to establish their initial value, since the property is not persisted and must obtain its value by running the calculation. However, default value rules are a little different - the property value is persisted, but the rule will run again if one of its predicates change. For a new entity, the default will always run on first access since there is no persisted value to use. Conversely for existing entities, if the entity has a persisted value for the property the rule will _**not**_ run unless one of its predicates fires a change event.

Calculations that are not accessed:
Typically a calculation will run for the first time as a result of first access of the property. For example, if its value is shown in the UI then the property must be accessed to get its value, which causes it to calculate its initial value. Because the calculation didn't previously have a value, it is treated as the initialization of the property and does not raise a change event. After the UI is initially rendered, if something causes the calculation to run again, it will then raise a change event, notifying subscribers that they should fetch the new value. However, this presumes that  something will access the calculation when the UI first renders. If the calculation is never accessed during initial render (ex: the field is hidden), then it won't establish its initial value, so when a predicate changes the result will be considered the calculation's initial value and will not raise a change event.

**Example**:

You have 3 fields on a page:
- `Name`: a text field
- `CleansedName`: a calculation which is not shown in the UI, which is based on `Name` (ex: converts the name to lower-case and removes whitespace and punctuation)
- `Username`: a text field which has a default of `= CleansedName ? CleansedName.Substring(0, 10) : "Username"`

If you load an existing record with a value of "John Doe" for `Name` and a `Username` of "johndoe", then change the name to "Test User", then the `Username` will still be "johndoe". This is because the `CleansedName` calculation is not accessed because it is not shown in the UI, so when `Name` changes it calculates for the first time and does not raise a change event. The expected behavior would be for the default to run and set `Username` to "testuser".

**Fix**:
In order to ensure that the default rule's calculated predicates fire a change event, we must ensure that the calculations are accessed when the object is initialized. This PR accomplishes that by running the default calculation and then discarding the value.