### PR TITLE
publish entity init events after setting properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- publish entity init events after setting properties during construction
 ## [0.8.31] - 2022-09-06
 ### Changed
 - Do not run default calculation rules until property access

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -66,16 +66,16 @@ export class Entity {
 			// Raise the initNew or initExisting event on this type and all base types
 			this.initialized = new Promise(resolve => {
 				context.whenReady(() => {
+					// Set values of new entity for provided properties
+					if (isNew && properties)
+						this.updateWithContext(context, properties);
+
 					for (let t = type; t; t = t.baseType) {
 						if (isNew)
 							(t.initNew as Event<Type, EntityInitNewEventArgs>).publish(t, { entity: this });
 						else
 							(t.initExisting as Event<Type, EntityInitExistingEventArgs>).publish(t, { entity: this });
 					}
-
-					// Set values of new entity for provided properties
-					if (isNew && properties)
-						this.updateWithContext(context, properties);
 
 					context.whenReady(resolve);
 				});

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -48,6 +48,15 @@ function resetModel() {
 				format: "[FullName] [Salary]"
 			},
 			ReleaseDate: Date,
+			ReleaseYear: {
+				type: Number,
+				default() {
+					return this.ReleaseDate ? this.ReleaseDate.getFullYear() : null;
+				},
+				required() {
+					return !isNaN(this.ReleaseYear);
+				}
+			},
 			Genres: "String[]",
 			Credits: {
 				type: "Credits"
@@ -101,6 +110,7 @@ const Alien = {
 	],
 	Id: null,
 	ReleaseDate: null,
+	ReleaseYear: null,
 	Title: "Alien"
 };
 
@@ -379,6 +389,11 @@ describe("Entity", () => {
 				const movie = await Types.Movie.meta.create(state);
 
 				expect(movie.serialize()).toEqual(state);
+			});
+
+			it("sets value correctly when validation rule also present", async() => {
+				const movie = await Types.Movie.meta.create({ ReleaseDate: new Date() });
+				expect(movie.ReleaseYear).toBe(new Date().getFullYear());
 			});
 		});
 	});


### PR DESCRIPTION
This fixes problems with a somewhat niche use case, where a default calculation rule references a property but does not list the property as a predicate. Without this change, a validation rule on the defaulted property would access the property when the entity is initialized, and calculate a default value _before_ the "dependency" property is set.

With this change, we ensure the "dependency" property is set based on the provided state for the entity before publishing the init event.