### PR TITLE
Run default values when serializing

### DIFF
--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -169,7 +169,7 @@ export class EntitySerializer {
 		flatMap(this.getPropertyInjectors(type), i => i.inject(entity))
 			.concat(type.properties
 				.filter(p => !p.isCalculated && !p.isConstant)
-				.map(prop => this.serializePropertyValue(entity, prop, entity.__fields__[prop.name], settings)))
+				.map(prop => this.serializePropertyValue(entity, prop, prop.value(entity), settings)))
 			.forEach(pair => {
 				if (pair && pair !== IgnoreProperty) {
 					if (result.hasOwnProperty(pair.key))

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -373,13 +373,13 @@ describe("Entity", () => {
 				Test: {
 					A: {
 						type: String,
-						default: 'a default'
+						default: "a default"
 					}
 				}
 			});
 
 			const instance = new defaultModel.Test();
-			expect(instance.serialize()).toEqual({"A": 'a default'});
+			expect(instance.serialize()).toEqual({"A": "a default"});
 		});
 	});
 

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -55,7 +55,8 @@ function resetModel() {
 				},
 				required() {
 					return !isNaN(this.ReleaseYear);
-				}
+				},
+				dependsOn: "ReleaseDate",
 			},
 			Genres: "String[]",
 			Credits: {
@@ -365,6 +366,20 @@ describe("Entity", () => {
 				T: "Alien"
 			};
 			expect(movie.serialize({ useAliases: true })).toEqual(expectedAlien);
+		});
+
+		it("default values are run when serializing", async () => {
+			const defaultModel  = new Model({
+				Test: {
+					A: {
+						type: String,
+						default: 'a default'
+					}
+				}
+			});
+
+			const instance = new defaultModel.Test();
+			expect(instance.serialize()).toEqual({"A": 'a default'});
 		});
 	});
 


### PR DESCRIPTION
Default values were not being run before serializing so `A: { type: String, default: 'a default'  }` this would serialize to `A: undefined` instead of `A: a default`