### PR TITLE
Only run default rule for list properties onInitNew

### DIFF
--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -1,4 +1,4 @@
-import { Rule, RuleOptions } from "./rule";
+import { Rule, RuleInvocationOptions, RuleOptions } from "./rule";
 import { Type } from "./type";
 import { Property, Property$init, Property$pendingInit, PropertyRuleOptions } from "./property";
 import { Entity } from "./entity";
@@ -32,6 +32,8 @@ export class CalculatedPropertyRule extends Rule {
 			if (options.property) {
 				property = typeof options.property === "string" ? rootType.getProperty(options.property) as Property : options.property as Property;
 
+				if (options.isDefaultValue && property.isList)
+					(options as RuleInvocationOptions).onInitNew = true;
 				// indicate that the rule is responsible for returning the value of the calculated property
 				options.returns = [property];
 			}

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -541,7 +541,7 @@ describe("Entity", () => {
 			expect(instance.Skills.length).toBe(2);
 			instance = await model.types.Person.create({ Skills: [] }) as any;
 			expect(instance.Skills.length).toBe(2);
-			instance = await model.types.Person.create({ Id: "test", Skills: [] }) as any;
+			instance = await model.types.Person.create({ Id: "test" }) as any;
 			expect(instance.Skills.length).toBe(0);
 		});
 	});

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -56,7 +56,7 @@ function resetModel() {
 				required() {
 					return !isNaN(this.ReleaseYear);
 				},
-				dependsOn: "ReleaseDate",
+				dependsOn: "ReleaseDate"
 			},
 			Genres: "String[]",
 			Credits: {
@@ -369,7 +369,7 @@ describe("Entity", () => {
 		});
 
 		it("default values are run when serializing", async () => {
-			const defaultModel  = new Model({
+			const defaultModel = new Model({
 				Test: {
 					A: {
 						type: String,
@@ -379,7 +379,7 @@ describe("Entity", () => {
 			});
 
 			const instance = new defaultModel.Test();
-			expect(instance.serialize()).toEqual({"A": "a default"});
+			expect(instance.serialize()).toEqual({ "A": "a default" });
 		});
 	});
 
@@ -464,6 +464,7 @@ describe("Entity", () => {
 				}
 			},
 			Person: {
+				Id: { identifier: true, type: String },
 				Skills: {
 					Id: { identifier: true, type: String },
 					type: "Skill[]",
@@ -532,6 +533,16 @@ describe("Entity", () => {
 			expect(instance.Skills.length).toBe(2);
 			instance.update({ Skills: [skillInstance] }, null, true);
 			expect(instance.Skills.length).toBe(1);
+		});
+
+		it("only runs default rule for list properties onInitNew", async () => {
+			const model = new Model(PersonWithSkillsModel);
+			let instance = await model.types.Person.create({}) as any;
+			expect(instance.Skills.length).toBe(2);
+			instance = await model.types.Person.create({ Skills: [] }) as any;
+			expect(instance.Skills.length).toBe(2);
+			instance = await model.types.Person.create({ Id: "test", Skills: [] }) as any;
+			expect(instance.Skills.length).toBe(0);
 		});
 	});
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -927,7 +927,8 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 			const underlyingValue = obj.__fields__[property.name];
 			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it
-			if (underlyingValue === property.defaultValue)
+			// List properties are defaulted onInitNew instead of on access
+			if (underlyingValue === property.defaultValue && !Array.isArray(underlyingValue))
 				Property$pendingInit(obj, property, true);
 		}
 	}

--- a/src/property.ts
+++ b/src/property.ts
@@ -927,7 +927,7 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 			const underlyingValue = obj.__fields__[property.name];
 			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it
-			if (underlyingValue === property.defaultValue || (property.isList && Array.isArray(underlyingValue) && underlyingValue.length === 0))
+			if (underlyingValue === property.defaultValue)
 				Property$pendingInit(obj, property, true);
 		}
 	}

--- a/src/type.ts
+++ b/src/type.ts
@@ -220,33 +220,6 @@ export class Type {
 		return obj;
 	}
 
-	forget(id: string, exactTypeOnly: boolean = false): void {
-		if (!id) {
-			throw new Error(`Method "${this.fullName}.meta.forget()" was called without a valid id argument.`);
-		}
-
-		const removeKey = (type: Type, key: string) => {
-			var obj = type.__pool__[key];
-			var objIndex = type.__known__.findIndex(e => e === obj);
-
-			// If exactTypeOnly is specified, don't return sub-types.
-			if (obj && exactTypeOnly === true && obj.meta.type !== type) {
-				throw new Error(`The entity with id='${id}' is expected to be of type '${type.fullName}' but found type '${obj.meta.type.fullName}'.`);
-			}
-
-			type.__known__.splice(objIndex, 1);
-			delete type.__pool__[key];
-		};
-
-		var key = id.toLowerCase();
-		if (exactTypeOnly)
-			removeKey(this, key);
-		else
-			for (var t: Type = this; t; t = t.baseType) {
-				removeKey(t, key);
-			}
-	}
-
 	// Gets an array of all objects of this type that have been registered.
 	// The returned array is observable and collection changed events will be raised
 	// when new objects are registered.

--- a/src/type.ts
+++ b/src/type.ts
@@ -220,6 +220,33 @@ export class Type {
 		return obj;
 	}
 
+	forget(id: string, exactTypeOnly: boolean = false): void {
+		if (!id) {
+			throw new Error(`Method "${this.fullName}.meta.forget()" was called without a valid id argument.`);
+		}
+
+		const removeKey = (type: Type, key: string) => {
+			var obj = type.__pool__[key];
+			var objIndex = type.__known__.findIndex(e => e === obj);
+
+			// If exactTypeOnly is specified, don't return sub-types.
+			if (obj && exactTypeOnly === true && obj.meta.type !== type) {
+				throw new Error(`The entity with id='${id}' is expected to be of type '${type.fullName}' but found type '${obj.meta.type.fullName}'.`);
+			}
+
+			type.__known__.splice(objIndex, 1);
+			delete type.__pool__[key];
+		};
+
+		var key = id.toLowerCase();
+		if (exactTypeOnly)
+			removeKey(this, key);
+		else
+			for (var t: Type = this; t; t = t.baseType) {
+				removeKey(t, key);
+			}
+	}
+
 	// Gets an array of all objects of this type that have been registered.
 	// The returned array is observable and collection changed events will be raised
 	// when new objects are registered.


### PR DESCRIPTION
Previously, list properties on existing entities could be calculated to their default value if the property was not specified when constructing the entity. This change effectively prevents a list property's default rule from running on property access, since the underlying value of a list property will never equal the default value. Instead, the list will be defaulted in response to the `initNew` event of the parent entity.

`console.log([] === []); // false`