### PR TITLE
fix: raise property change when default calculation rule runs for list

### DIFF
--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -14,6 +14,7 @@ export class CalculatedPropertyRule extends Rule {
 
 	// Public settable properties that are simple values with no side-effects or logic
 	defaultIfError: any;
+	private isDefaultValue: boolean;
 
 	// Backing fields for properties that are settable and also derived from
 	// other data, calculated in some way, or cannot simply be changed
@@ -34,6 +35,7 @@ export class CalculatedPropertyRule extends Rule {
 
 				if (options.isDefaultValue && property.isList)
 					(options as RuleInvocationOptions).onInitNew = true;
+
 				// indicate that the rule is responsible for returning the value of the calculated property
 				options.returns = [property];
 			}
@@ -57,6 +59,8 @@ export class CalculatedPropertyRule extends Rule {
 
 		// Public settable properties
 		this.defaultIfError = defaultIfError;
+
+		this.isDefaultValue = !!options.isDefaultValue;
 
 		// Backing fields for properties
 		if (calculateFn) Object.defineProperty(this, "_calculateFn", { enumerable: false, value: calculateFn, writable: true });
@@ -107,7 +111,8 @@ export class CalculatedPropertyRule extends Rule {
 			const newList = newValue;
 
 			// ensure the initial calculation of the list does not raise change events
-			if (Property$pendingInit(obj, this.property))
+			// defaulting a list property should raise change events
+			if (!this.isDefaultValue && Property$pendingInit(obj, this.property))
 				Property$init(this.property, obj, newList);
 			else {
 				// compare the new list to the old one to see if changes were made

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -537,12 +537,27 @@ describe("Entity", () => {
 
 		it("only runs default rule for list properties onInitNew", async () => {
 			const model = new Model(PersonWithSkillsModel);
+
 			let instance = await model.types.Person.create({}) as any;
 			expect(instance.Skills.length).toBe(2);
+
 			instance = await model.types.Person.create({ Skills: [] }) as any;
 			expect(instance.Skills.length).toBe(2);
+
 			instance = await model.types.Person.create({ Id: "test" }) as any;
 			expect(instance.Skills.length).toBe(0);
+		});
+
+		it("triggers property change when default calculation runs for list", async () => {
+			const model = new Model(PersonWithSkillsModel);
+
+			const skillsChanged = jest.fn();
+			model.types["Person"].getProperty("Skills").changed.subscribe(skillsChanged);
+
+			let instance = await model.types.Person.create({}) as any;
+			expect(instance.Skills.length).toBe(2);
+
+			expect(skillsChanged).toBeCalledTimes(1);
 		});
 	});
 

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -554,7 +554,7 @@ describe("Entity", () => {
 			const skillsChanged = jest.fn();
 			model.types["Person"].getProperty("Skills").changed.subscribe(skillsChanged);
 
-			let instance = await model.types.Person.create({}) as any;
+			const instance = await model.types.Person.create({}) as any;
 			expect(instance.Skills.length).toBe(2);
 
 			expect(skillsChanged).toBeCalledTimes(1);


### PR DESCRIPTION
With the changes to support calculated list properties, the behavior of _defaulted_ list properties changed such that the initial calculation of the list's default value did not trigger change for the list property itself. This behavior is inconsistent with default calculations for non-list properties, which do trigger a change event when they are defaulted for the first time.