### PR TITLE
Remove duplicate exports of 'initilization-context'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export * from "./property-path";
 export * from "./entity";
 export * from "./object-meta";
 export * from "./format";
-export * from "./initilization-context";
 export * from "./observable-array";
 
 // Conditions, etc.


### PR DESCRIPTION
The "initialization-context" module is imported / exported multiple times. Removed the duplicate, leaving the one under the "serialization" heading.