### PR TITLE
Improve type checking of property options

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -603,6 +603,11 @@ export interface PropertyOptions {
 	label?: string;
 
 	/**
+	 * Whether the property is an identifier for the type
+	 */
+	identifier?: boolean;
+
+	/**
 	 * The optional path to use for the source of the property's label, if it contains format tokens
 	 */
 	labelSource?: string;

--- a/src/type.ts
+++ b/src/type.ts
@@ -448,7 +448,7 @@ export class Type {
 
 				// Property
 				else {
-					member = { ...member };
+					member = { ...member } as PropertyOptions;
 
 					// Get Property
 					let property = this.getProperty(name);


### PR DESCRIPTION
- Add `identifier` to property options
- Cast to `PropertyOptions` in `type.extend`