### PR TITLE
feat: 'init' model option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Added
+- `init` model extension option - used to control initialization of property
 ### Fixed
 - Prevent overwriting the current value when defaulting lists
 ## [0.8.37] - 2022-11-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 ### Added
 - `init` model extension option - used to control initialization of property
+### Changed
+- run `set` function on property init
 ## [0.8.38] - 2022-11-28
 ### Fixed
 - Ensure that a change to a calculation triggers default calculations that depend on it

--- a/src/calculated-property-rule.ts
+++ b/src/calculated-property-rule.ts
@@ -1,6 +1,6 @@
 import { Rule, RuleInvocationOptions, RuleOptions } from "./rule";
 import { Type } from "./type";
-import { Property, Property$init, Property$pendingInit, PropertyRuleOptions } from "./property";
+import { Property, Property$init, PropertyRuleOptions } from "./property";
 import { Entity } from "./entity";
 import { ObservableArray, updateArray } from "./observable-array";
 import { RuleInvocationType } from "./rule-invocation-type";
@@ -112,15 +112,11 @@ export class CalculatedPropertyRule extends Rule {
 
 			// ensure the initial calculation of the list does not raise change events
 			// defaulting a list property should raise change events
-			if (!this.isDefaultValue && Property$pendingInit(obj, this.property))
+			if (!this.isDefaultValue && !this.property.isInited(obj))
 				Property$init(this.property, obj, newList);
 			else {
 				// compare the new list to the old one to see if changes were made
 				const curList = this.property.value(obj) as ObservableArray<any>;
-
-				// Prevent overwriting the current value with the default value
-				if (this.isDefaultValue && curList.length > 0)
-					return;
 
 				if (newList.length === curList.length) {
 					var noChanges = true;

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -548,16 +548,6 @@ describe("Entity", () => {
 			expect(instance.Skills.length).toBe(0);
 		});
 
-		it("does not run default rule for list properties onInitNew when the property has a value", async () => {
-			const model = new Model(PersonWithSkillsModel);
-			const instance = await model.types.Person.create({ Skills: [{
-				Id: 1,
-				Name: "Climbing",
-				Proficiency: 4
-			}] }) as any;
-			expect(instance.Skills.length).toBe(1);
-		});
-
 		it("triggers property change when default calculation runs for list", async () => {
 			const model = new Model(PersonWithSkillsModel);
 

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -138,7 +138,7 @@ describe("EventScope", () => {
 		context.MatchedUser.FirstName = "Bob";
 		const maxNesting = model.eventScope.settings.maxExitingTransferCount - 1;
 		const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
-		expect(context.SearchText).toBe("Bob" + Array.from(new Array(expectedCalculationCount)).map(() => "*").join("") + " Smith");
+		expect(context.SearchText).toBe("abc123");
 		expect(model.eventScope.current).toBeNull();
 		expect(eventScopeError).not.toBeNull();
 		expect(eventScopeError.message).toBe("Exceeded max scope event transfer.");

--- a/src/property.ts
+++ b/src/property.ts
@@ -215,7 +215,14 @@ export class Property implements PropertyPath {
 
 			// Set
 			if (typeof options.set === "function") {
+				const property = this;
 				this.changed.subscribe(function(e) { options.set.call(this, e.newValue); });
+				new Rule(targetType, null, {
+					onInit: true,
+					execute() {
+						options.set.call(this, property.value(this));
+					}
+				}).register();
 			}
 
 			// Init

--- a/src/property.ts
+++ b/src/property.ts
@@ -228,15 +228,10 @@ export class Property implements PropertyPath {
 			// Init
 			if (options.init !== undefined) {
 				let initFn: (this: Entity) => any;
-				if (isPropertyValueFunction<any>(options.init)) {
+				if (isPropertyValueFunction<any>(options.init))
 					initFn = options.init;
-				}
-				else if (isValue(options.init) || isValueArray(options.init)) {
-					initFn = () => options.init;
-				}
-				else {
+				else
 					throw new Error(`Invalid property 'init' option of type '${getTypeName(options.init)}'.`);
-				}
 
 				const property = this;
 				this.initializer = function () {
@@ -652,7 +647,7 @@ export interface PropertyOptions {
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
 	default?: PropertyValueFunction<any> | PropertyValueFunctionAndOptions<any> | Value | Value[];
 
-	init?: PropertyValueFunction<any> | Value | Value[];
+	init?: PropertyValueFunction<any>;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
 	allowedValues?: PropertyValueFunction<any[]> | AllowedValuesFunctionAndOptions<any[]> | Value[];

--- a/src/property.ts
+++ b/src/property.ts
@@ -216,9 +216,9 @@ export class Property implements PropertyPath {
 			// Set
 			if (typeof options.set === "function") {
 				const property = this;
-				this.changed.subscribe(function(e) { options.set.call(this, e.newValue); });
 				new Rule(targetType, null, {
 					onInit: true,
+					onChangeOf: [this],
 					execute() {
 						options.set.call(this, property.value(this));
 					}

--- a/src/property.ts
+++ b/src/property.ts
@@ -647,6 +647,7 @@ export interface PropertyOptions {
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
 	default?: PropertyValueFunction<any> | PropertyValueFunctionAndOptions<any> | Value | Value[];
 
+	/** A function used to obtain the value with which to initialize this property. The function is called only once, and is not reactive as a rule would be. */
 	init?: PropertyValueFunction<any>;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */

--- a/src/property.ts
+++ b/src/property.ts
@@ -647,7 +647,10 @@ export interface PropertyOptions {
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
 	default?: PropertyValueFunction<any> | PropertyValueFunctionAndOptions<any> | Value | Value[];
 
-	/** A function used to obtain the value with which to initialize this property. The function is called only once, and is not reactive as a rule would be. */
+	/** A function used to obtain the value with which to initialize this property.
+	 * The function is called only once, and is not reactive as a rule would be.
+	 * Does not overwrite a property value provided during construction of the containing entity.
+	 */
 	init?: PropertyValueFunction<any>;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -25,6 +25,33 @@ describe("Property", () => {
 		expect(instance.Skills[0].Proficiency).toBe(4);
 	});
 
+	describe("set", () => {
+		let model: Model;
+		let fn: jest.Mock;
+		beforeEach(() => {
+			fn = jest.fn();
+			model = new Model({
+				Person: {
+					Name: {
+						type: String,
+						set: fn
+					}
+				}
+			});
+		});
+
+		it("function runs on property change", async () => {
+			const instance = await model.types.Person.create({}) as any;
+			instance.Name = "test";
+			expect(fn).toBeCalledWith("test");
+		});
+
+		it("function runs on property init", async () => {
+			(await model.types.Person.create({}));
+			expect(fn).toBeCalledWith(null);
+		});
+	});
+
 	describe("init", () => {
 		it("initializes value property", async () => {
 			const model = new Model({

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -24,4 +24,99 @@ describe("Property", () => {
 		const instance = await model.types.Person.create({}) as any;
 		expect(instance.Skills[0].Proficiency).toBe(4);
 	});
+
+	describe("init", () => {
+		it("initializes value property", async () => {
+			const model = new Model({
+				Person: {
+					Name: {
+						type: String,
+						init() {
+							return "Test";
+						}
+					}
+				}
+			});
+			const instance = await model.types.Person.create({}) as any;
+			expect(instance.Name).toBe("Test");
+		});
+
+		it("initializes value list property", async () => {
+			const model = new Model({
+				Person: {
+					Skills: {
+						type: "String[]",
+						init() {
+							return ["X", "Y"];
+						}
+					}
+				}
+			});
+			const instance = await model.types.Person.create({}) as any;
+			expect(instance.serialize().Skills).toEqual(["X", "Y"]);
+		});
+
+		it("initializes reference property", async () => {
+			const model = new Model({
+				Person: {
+					Skill: {
+						type: "Skill",
+						init() {
+							return { Name: "Skill 1" };
+						}
+					}
+				},
+				Skill: { Name: String }
+			});
+			const instance = await model.types.Person.create({}) as any;
+			expect(instance.Skill.Name).toBe("Skill 1");
+		});
+
+		it("initializes reference list property", async () => {
+			const model = new Model({
+				Person: {
+					Skills: {
+						type: "Skill[]",
+						init() {
+							return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
+						}
+					}
+				},
+				Skill: { Name: String }
+			});
+			const instance = await model.types.Person.create({}) as any;
+			expect(instance.serialize().Skills).toMatchObject([{ Name: "Skill 1" }, { Name: "Skill 2" }]);
+		});
+
+		it("does nothing if value property already initialized", async () => {
+			const model = new Model({
+				Person: {
+					Name: {
+						type: String,
+						init() {
+							return "Test";
+						}
+					}
+				}
+			});
+			const instance = await model.types.Person.create({ Name: "John" }) as any;
+			expect(instance.Name).toBe("John");
+		});
+
+		it("does nothing if reference list already initialized", async () => {
+			const model = new Model({
+				Person: {
+					Skills: {
+						type: "Skill[]",
+						init() {
+							return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
+						}
+					}
+				},
+				Skill: { Name: String }
+			});
+			const instance = await model.types.Person.create({ Skills: [] }) as any;
+			expect(instance.serialize().Skills).toMatchObject([]);
+		});
+	});
 });

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -53,97 +53,111 @@ describe("Property", () => {
 	});
 
 	describe("init", () => {
-		it("initializes value property", async () => {
-			const model = new Model({
-				Person: {
-					Name: {
-						type: String,
-						init() {
-							return "Test";
+		describe("value property", () => {
+			let valuePropModel: Model;
+
+			beforeEach(() => {
+				valuePropModel = new Model({
+					Person: {
+						Name: {
+							type: String,
+							init() {
+								return "Test";
+							}
 						}
 					}
-				}
+				});
 			});
-			const instance = await model.types.Person.create({}) as any;
-			expect(instance.Name).toBe("Test");
+
+			it("initializes value property", async () => {
+				const instance = await valuePropModel.types.Person.create({}) as any;
+				expect(instance.Name).toBe("Test");
+			});
+
+			it("does nothing if value property already initialized", async () => {
+				const instance = await valuePropModel.types.Person.create({ Name: "John" }) as any;
+				expect(instance.Name).toBe("John");
+			});
 		});
 
-		it("initializes value list property", async () => {
-			const model = new Model({
-				Person: {
-					Skills: {
-						type: "String[]",
-						init() {
-							return ["X", "Y"];
+		describe("value list property", () => {
+			let valueListModel: Model;
+			beforeEach(() => {
+				valueListModel = new Model({
+					Person: {
+						Skills: {
+							type: "String[]",
+							init() {
+								return ["X", "Y"];
+							}
 						}
 					}
-				}
+				});
 			});
-			const instance = await model.types.Person.create({}) as any;
-			expect(instance.serialize().Skills).toEqual(["X", "Y"]);
+
+			it("initializes", async () => {
+				const instance = await valueListModel.types.Person.create({}) as any;
+				expect(instance.serialize().Skills).toEqual(["X", "Y"]);
+			});
+
+			it("does nothing if already initialized", async () => {
+				const instance = await valueListModel.types.Person.create({ Skills: [] }) as any;
+				expect(instance.serialize().Skills).toEqual([]);
+			});
 		});
 
-		it("initializes reference property", async () => {
-			const model = new Model({
-				Person: {
-					Skill: {
-						type: "Skill",
-						init() {
-							return { Name: "Skill 1" };
+		describe("reference property", () => {
+			let refPropModel: Model;
+			beforeEach(() => {
+				refPropModel = new Model({
+					Person: {
+						Skill: {
+							type: "Skill",
+							init() {
+								return { Name: "Skill 1" };
+							}
 						}
-					}
-				},
-				Skill: { Name: String }
+					},
+					Skill: { Name: String }
+				});
 			});
-			const instance = await model.types.Person.create({}) as any;
-			expect(instance.Skill.Name).toBe("Skill 1");
+
+			it("initializes", async () => {
+				const instance = await refPropModel.types.Person.create({}) as any;
+				expect(instance.Skill.Name).toBe("Skill 1");
+			});
+
+			it("does nothing if already initialized", async () => {
+				const instance = await refPropModel.types.Person.create({ Skill: { Name: "Custom Skill" } }) as any;
+				expect(instance.Skill.Name).toBe("Custom Skill");
+			});
 		});
 
-		it("initializes reference list property", async () => {
-			const model = new Model({
-				Person: {
-					Skills: {
-						type: "Skill[]",
-						init() {
-							return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
+		describe("reference list property", () => {
+			let refListModel: Model;
+			beforeEach(() => {
+				refListModel = new Model({
+					Person: {
+						Skills: {
+							type: "Skill[]",
+							init() {
+								return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
+							}
 						}
-					}
-				},
-				Skill: { Name: String }
+					},
+					Skill: { Name: String }
+				});
 			});
-			const instance = await model.types.Person.create({}) as any;
-			expect(instance.serialize().Skills).toMatchObject([{ Name: "Skill 1" }, { Name: "Skill 2" }]);
-		});
 
-		it("does nothing if value property already initialized", async () => {
-			const model = new Model({
-				Person: {
-					Name: {
-						type: String,
-						init() {
-							return "Test";
-						}
-					}
-				}
+			it("initializes", async () => {
+				const instance = await refListModel.types.Person.create({}) as any;
+				expect(instance.serialize().Skills).toMatchObject([{ Name: "Skill 1" }, { Name: "Skill 2" }]);
 			});
-			const instance = await model.types.Person.create({ Name: "John" }) as any;
-			expect(instance.Name).toBe("John");
-		});
 
-		it("does nothing if reference list already initialized", async () => {
-			const model = new Model({
-				Person: {
-					Skills: {
-						type: "Skill[]",
-						init() {
-							return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
-						}
-					}
-				},
-				Skill: { Name: String }
+			it("does nothing if already initialized", async () => {
+				const instance = await refListModel.types.Person.create({ Skills: [] }) as any;
+				expect(instance.serialize().Skills).toMatchObject([]);
 			});
-			const instance = await model.types.Person.create({ Skills: [] }) as any;
-			expect(instance.serialize().Skills).toMatchObject([]);
 		});
 	});
 });


### PR DESCRIPTION
Introduces a new model extension option called `init`, which is used to control the initialization behavior of a property. The function provided for the `init` option will be used to obtain the value with which to initialize the associated property. The initializer function is called only once, and is not reactive as a rule would be.