### PR TITLE
fix: condition not applied to correct targets involving nested properties

### DIFF
--- a/src/condition-rule.unit.ts
+++ b/src/condition-rule.unit.ts
@@ -36,4 +36,64 @@ describe("ConditionRule", () => {
 		expect(p.meta.conditions).toHaveLength(1);
 		expect(p.meta.conditions[0].condition.message).toBe("Test error message.");
 	});
+
+	test("Nested Property", async () =>{
+		const model = await createModel({
+			Test: {
+				Section: {
+					type: "Section"
+				},
+				Text: {
+					type: String,
+					get: {
+						dependsOn: "Section.Text",
+						function() { return this.Section.Text; }
+					},
+					error: {
+						dependsOn: "Calculation",
+						function: function() {
+							if (this.Calculation !== null)
+								return "Calculation Error Message";
+						}
+					}
+				},
+				Calculation: {
+					type: String,
+					get: {
+						dependsOn: "Section.Text",
+						function() { return this.Section.Text; }
+					},
+					error: {
+						dependsOn: "{Calculation, Section.Text}",
+						function: function() {
+							if (((this ? this.Calculation : null) !== null)) {
+								return "Test error message.";
+							}
+						}
+					}
+
+				}
+			},
+			Section: {
+				Text: {
+					type: String
+				}
+			},
+			Calculation: {
+				type: String
+			}
+		}) as any;
+		const Test = model.getJsType("Test");
+		const Section = model.getJsType("Section");
+		const Calc = model.getJsType("Calculation");
+		var p = new Test({
+			Section: new Section({ Text: null }),
+			Calculation: new Calc("Test")
+		});
+		expect(p.meta.conditions).toHaveLength(0);
+		p.Section.Text = "x";
+		expect(p.meta.conditions).toHaveLength(2);
+		expect(p.meta.conditions[0].condition.message).toBe("Calculation Error Message");
+		expect(p.meta.conditions[1].condition.message).toBe("Test error message.");
+	});
 });

--- a/src/condition.ts
+++ b/src/condition.ts
@@ -39,6 +39,8 @@ export class Condition {
 				// we don't want to construct ConditionTargets as we're processing the path because we may not have gathered all targeted properties,
 				// and the constructor triggers change on the entity meta's conditions list, which should be in a correct state before publishing the event
 				path.each(target, (entity, property) => {
+					if (property !== path.lastProperty)
+						return;
 					// see if a target already exists for the current instance
 					let targetInfo = targetInfos.find(t => t.entity === entity);
 
@@ -50,7 +52,7 @@ export class Condition {
 					// otherwise, just ensure it references the current step
 					else if (!targetInfo.properties.includes(property))
 						targetInfo.properties.push(property);
-				}, path.lastProperty);
+				});
 
 				// construct the ConditionTargets here now that we've gathered all information
 				targets.push(...targetInfos.map(i => new ConditionTarget(this, i.entity, i.properties)));


### PR DESCRIPTION
Solution for [this bug](https://dev.azure.com/cognitoforms/Cognito%20Forms/_workitems/edit/27500) 
- replace the filter parameter with a check for equality with the last property inside the callback

This issue was that the filter was causing the `each` method to miss nested properties (like for when a calculation should show an error both on itself and on the field featured in the calculation). 

Removing the filter guarantees the callback to create an error is always called with every property, and the added if statement checks to see if the property is the lastProperty so that the error is only created for matching properties