### PR TITLE
Change property initialization to use update after establishing a default property value

### DIFF
--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -169,7 +169,7 @@ describe("CalculateRule", () => {
 		});
 	});
 
-	describe("calculated list", async () => {
+	describe("calculated list", () => {
 		let model;
 		beforeEach(() => {
 			model = new Model({

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -6,6 +6,7 @@ import { ObjectMeta } from "./object-meta";
 import { Property, Property$init, Property$setter } from "./property";
 import { ObjectLookup, entries } from "./helpers";
 import { DefaultSerializationSettings } from "./entity-serializer";
+
 export class Entity {
 	static ctorDepth: number = 0;
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -233,10 +233,7 @@ export class Property implements PropertyPath {
 				else
 					throw new Error(`Invalid property 'init' option of type '${getTypeName(options.init)}'.`);
 
-				const property = this;
-				this.initializer = function () {
-					return targetType.model.serializer.deserialize(this, initFn.call(this), property, new InitializationContext(true));
-				};
+				this.initializer = initFn;
 			}
 
 			// Default
@@ -913,26 +910,6 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 	});
 }
 
-function Property$getInitialValue(property: Property, obj: Entity): any {
-	// Constant
-	if (property.isConstant)
-		return typeof property.constant === "function" ? (property.constant = property.constant()) : property.constant;
-
-	var val = property.initializer
-		? property.initializer.call(obj)
-		: property.defaultValue;
-
-	if (Array.isArray(val)) {
-		val = ObservableArray.ensureObservable(val as any[]);
-
-		// Override the default toString on arrays so that we get a comma-delimited list
-		// TODO: Implement toString on observable list?
-		// val.toString = Property$_arrayToString.bind(val);
-	}
-
-	return val;
-}
-
 export function Property$init(property: Property, obj: Entity, val: any): void {
 	Property$pendingInit(obj, property, false);
 
@@ -953,7 +930,37 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 		// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
 		if (!property.isCalculated) {
-			Property$init(property, obj, Property$getInitialValue(property, obj));
+			let initData = null;
+			let initValue = null;
+
+			// Constant
+			if (property.isConstant)
+				initValue = typeof property.constant === "function" ? (property.constant = property.constant()) : property.constant;
+			else if (property.initializer) {
+				initValue = property.initializer.call(obj);
+				if (isEntityType(property.propertyType)) {
+					initData = initValue;
+					if (property.isList)
+						initValue = [];
+					else
+						initValue = new property.propertyType();
+				}
+			}
+			else
+				initValue = property.defaultValue;
+
+			if (Array.isArray(initValue)) {
+				initValue = ObservableArray.ensureObservable(initValue as any[]);
+
+				// Override the default toString on arrays so that we get a comma-delimited list
+				// TODO: Implement toString on observable list?
+				// val.toString = Property$_arrayToString.bind(val);
+			}
+
+			Property$init(property, obj, initValue);
+
+			if (initData)
+				obj.update(property.name, initData);
 
 			const underlyingValue = obj.__fields__[property.name];
 			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it

--- a/src/property.ts
+++ b/src/property.ts
@@ -919,6 +919,7 @@ function Property$getInitialValue(property: Property): any {
 
 	if (Array.isArray(val)) {
 		val = ObservableArray.ensureObservable(val as any[]);
+
 		// Override the default toString on arrays so that we get a comma-delimited list
 		// TODO: Implement toString on observable list?
 		// val.toString = Property$_arrayToString.bind(val);

--- a/src/property.ts
+++ b/src/property.ts
@@ -917,6 +917,13 @@ function Property$getInitialValue(property: Property, obj: Entity): any {
 
 	var val = property.defaultValue;
 
+	if (Array.isArray(val)) {
+		val = ObservableArray.ensureObservable(val as any[]);
+		// Override the default toString on arrays so that we get a comma-delimited list
+		// TODO: Implement toString on observable list?
+		// val.toString = Property$_arrayToString.bind(val);
+	}
+
 	return val;
 }
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -910,7 +910,7 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 	});
 }
 
-function Property$getInitialValue(property: Property, obj: Entity): any {
+function Property$getInitialValue(property: Property): any {
 	// Constant
 	if (property.isConstant)
 		return typeof property.constant === "function" ? (property.constant = property.constant()) : property.constant;
@@ -947,7 +947,7 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 		// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
 		if (!property.isCalculated) {
-			Property$init(property, obj, Property$getInitialValue(property, obj));
+			Property$init(property, obj, Property$getInitialValue(property));
 			if (property.initializer)
 				obj.update(property.name, property.initializer.call(obj));
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -910,6 +910,16 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 	});
 }
 
+function Property$getInitialValue(property: Property, obj: Entity): any {
+	// Constant
+	if (property.isConstant)
+		return typeof property.constant === "function" ? (property.constant = property.constant()) : property.constant;
+
+	var val = property.defaultValue;
+
+	return val;
+}
+
 export function Property$init(property: Property, obj: Entity, val: any): void {
 	Property$pendingInit(obj, property, false);
 
@@ -930,37 +940,9 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 
 		// Do not initialize calculated properties. Calculated properties should be initialized using a property get rule.
 		if (!property.isCalculated) {
-			let initData = null;
-			let initValue = null;
-
-			// Constant
-			if (property.isConstant)
-				initValue = typeof property.constant === "function" ? (property.constant = property.constant()) : property.constant;
-			else if (property.initializer) {
-				initValue = property.initializer.call(obj);
-				if (isEntityType(property.propertyType)) {
-					initData = initValue;
-					if (property.isList)
-						initValue = [];
-					else
-						initValue = new property.propertyType();
-				}
-			}
-			else
-				initValue = property.defaultValue;
-
-			if (Array.isArray(initValue)) {
-				initValue = ObservableArray.ensureObservable(initValue as any[]);
-
-				// Override the default toString on arrays so that we get a comma-delimited list
-				// TODO: Implement toString on observable list?
-				// val.toString = Property$_arrayToString.bind(val);
-			}
-
-			Property$init(property, obj, initValue);
-
-			if (initData)
-				obj.update(property.name, initData);
+			Property$init(property, obj, Property$getInitialValue(property, obj));
+			if (property.initializer)
+				obj.update(property.name, property.initializer.call(obj));
 
 			const underlyingValue = obj.__fields__[property.name];
 			// Mark the property as pending initialization if it still has no underlying value, or is the property type's default, to allow default calculation rules to run for it

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -3,6 +3,56 @@ import { Entity } from "./entity";
 import { IgnoreProperty, PropertyConverter, PropertySerializationResult } from "./entity-serializer";
 import { Model } from "./model";
 import { Property } from "./property";
+import { isEntityType } from "./type";
+
+class IgnorePropertyConverter extends PropertyConverter {
+	readonly propertyName: string;
+	constructor(propertyName: string) {
+		super();
+		this.propertyName = propertyName;
+	}
+	shouldConvert(context: Entity, prop: Property): boolean {
+		if (prop.name === this.propertyName)
+			return true;
+		return false;
+	}
+	serialize(): PropertySerializationResult {
+		return IgnoreProperty;
+	}
+}
+
+class InitializeBackReferencesConverter extends PropertyConverter {
+	readonly rootPropertyName: string;
+	readonly parentPropertyName: string;
+	constructor(rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
+		super();
+		this.rootPropertyName = rootPropertyName;
+		this.parentPropertyName = parentPropertyName;
+	}
+	shouldConvert(context: Entity, prop: Property): boolean {
+		const shouldConvert = prop.name !== this.rootPropertyName && prop.name !== this.parentPropertyName
+			&& isEntityType(prop.propertyType)
+			&& (!!prop.propertyType.meta.getProperty(this.rootPropertyName) || !!prop.propertyType.meta.getProperty(this.parentPropertyName));
+		return shouldConvert;
+	}
+	deserialize(context: Entity, value: any, prop: Property) {
+		if (value && isEntityType(prop.propertyType)) {
+			if (Array.isArray(value))
+				value = value.map(item => this.deserialize(context, item, prop));
+			else {
+				// avoid modifying the provided object
+				value = Object.assign({}, value);
+				if (prop.propertyType.meta.getProperty(this.parentPropertyName))
+					value[this.parentPropertyName] = context;
+				if (prop.propertyType.meta.getProperty(this.rootPropertyName))
+					value[this.rootPropertyName] = this.rootPropertyName in context
+						? context[this.rootPropertyName]
+						: context;
+			}
+		}
+		return value;
+	}
+}
 
 describe("Property", () => {
 	it("can have a constant value", async () => {
@@ -110,24 +160,95 @@ describe("Property", () => {
 		});
 
 		describe("reference property", () => {
+			function propagateRootProperty(parent: Entity, child: Entity, rootPropertyName: string = "Root") {
+				// In case the parent's Root property is not yet set, propagate when it is set
+				if (!parent[rootPropertyName])
+					parent.meta.type.getProperty(rootPropertyName).changed.subscribeOne(e => (child[rootPropertyName] = e.newValue));
+				else
+					child[rootPropertyName] = parent[rootPropertyName];
+			}
+
+			function setBackReferenceProperties(parent: Entity, child: Entity, rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
+				if (parentPropertyName in child) {
+					child[parentPropertyName] = parent;
+					propagateRootProperty(parent, child, rootPropertyName);
+				}
+				else
+					child[rootPropertyName] = parent;
+			}
+
+			function ensureChildProperties(parent: Entity, propertyName: string, rootPropertyName: string = "Root", parentPropertyName: string = "Parent"): void {
+				const value = parent.get(propertyName);
+				if (Array.isArray(value)) {
+					value.forEach(item => setBackReferenceProperties(parent, item, rootPropertyName, parentPropertyName));
+				}
+				else if (value) {
+					setBackReferenceProperties(parent, value, rootPropertyName, parentPropertyName);
+				}
+			}
+
 			let refPropModel: Model;
 			beforeEach(() => {
 				refPropModel = new Model({
 					Person: {
 						Skill: {
 							type: "Skill",
+							set: function() { return ensureChildProperties(this, "Skill"); },
 							init() {
-								return { Name: "Skill 1" };
+								return refPropModel.types["Skill"].createIfNotExists({});
 							}
 						}
 					},
-					Skill: { Name: String }
+					Skill: {
+						Name: String,
+						Code: String,
+						Root: {
+							type: "Person"
+						},
+						Metadata: {
+							type: "SkillMetadata",
+							set: function() { return ensureChildProperties(this, "Metadata"); },
+							init() {
+								return refPropModel.types["SkillMetadata"].createIfNotExists({});
+							}
+						}
+					},
+					SkillMetadata: {
+						Code: {
+							type: String,
+							format: {
+								description: "AAA-000",
+								expression: /^\s*([A-Z]+)-(\d)\s*$/g,
+								message: "Code must be formatted as 'AAA-000'.",
+								reformat: "$1-$2"
+							},
+							default: {
+								dependsOn: "Parent.Code",
+								function: function() { return this.Root ? this.Root.Skill ? this.Root.Skill.Code : null : null; }
+							}
+						},
+						Root: {
+							type: "Person"
+						},
+						Parent: {
+							type: "Skill"
+						}
+					}
+				}, {
+					maxEventScopeDepth: 100,
+					maxExitingEventScopeTransferCount: 500
 				});
+
+				refPropModel.serializer.registerPropertyConverter(new IgnorePropertyConverter("Root"));
+				refPropModel.serializer.registerPropertyConverter(new IgnorePropertyConverter("Parent"));
+				refPropModel.serializer.registerPropertyConverter(new InitializeBackReferencesConverter("Root", "Parent"));
 			});
 
 			it("initializes", async () => {
+				const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
 				const instance = await refPropModel.types.Person.create({}) as any;
-				expect(instance.Skill.Name).toBe("Skill 1");
+				expect(instance.Skill.Name).toBe(null);
+				expect(consoleWarn).not.toBeCalled();
 			});
 
 			it("does nothing if already initialized", async () => {
@@ -137,22 +258,6 @@ describe("Property", () => {
 		});
 
 		describe("reference list property", () => {
-			class IgnorePropertyConverter extends PropertyConverter {
-				readonly propertyName: string;
-				constructor(propertyName: string) {
-					super();
-					this.propertyName = propertyName;
-				}
-				shouldConvert(context: Entity, prop: Property): boolean {
-					if (prop.name === this.propertyName)
-						return true;
-					return false;
-				}
-				serialize(): PropertySerializationResult {
-					return IgnoreProperty;
-				}
-			}
-
 			let refListModel: Model;
 			beforeEach(() => {
 				refListModel = new Model({

--- a/test/back-references.unit.ts
+++ b/test/back-references.unit.ts
@@ -313,7 +313,7 @@ describe("Back-reference properties", () => {
 			deeplyNestedModel.serializer.registerPropertyConverter(new InitializeBackReferencesConverter("Root", "Parent"));
 		});
 
-		it.only("can be established via property initializers", async () => {
+		it("can be established via property initializers", async () => {
 			const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
 			const instance = await deeplyNestedModel.types.Root.create({}) as any;
 			expect(instance.SectionA.Text).toBe(null);

--- a/test/back-references.unit.ts
+++ b/test/back-references.unit.ts
@@ -1,0 +1,194 @@
+/* eslint-disable no-new */
+import { Entity } from "../src/entity";
+import { IgnoreProperty, PropertyConverter, PropertySerializationResult } from "../src/entity-serializer";
+import { Model } from "../src/model";
+import { Property } from "../src/property";
+import { isEntityType } from "../src/type";
+
+class IgnorePropertyConverter extends PropertyConverter {
+	readonly propertyName: string;
+	constructor(propertyName: string) {
+		super();
+		this.propertyName = propertyName;
+	}
+	shouldConvert(context: Entity, prop: Property): boolean {
+		if (prop.name === this.propertyName)
+			return true;
+		return false;
+	}
+	serialize(): PropertySerializationResult {
+		return IgnoreProperty;
+	}
+}
+
+class InitializeBackReferencesConverter extends PropertyConverter {
+	readonly rootPropertyName: string;
+	readonly parentPropertyName: string;
+	constructor(rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
+		super();
+		this.rootPropertyName = rootPropertyName;
+		this.parentPropertyName = parentPropertyName;
+	}
+	shouldConvert(context: Entity, prop: Property): boolean {
+		const shouldConvert = prop.name !== this.rootPropertyName && prop.name !== this.parentPropertyName
+			&& isEntityType(prop.propertyType)
+			&& (!!prop.propertyType.meta.getProperty(this.rootPropertyName) || !!prop.propertyType.meta.getProperty(this.parentPropertyName));
+		return shouldConvert;
+	}
+	deserialize(context: Entity, value: any, prop: Property) {
+		if (value && isEntityType(prop.propertyType)) {
+			if (Array.isArray(value))
+				value = value.map(item => this.deserialize(context, item, prop));
+			else {
+				// avoid modifying the provided object
+				value = Object.assign({}, value);
+				if (prop.propertyType.meta.getProperty(this.parentPropertyName))
+					value[this.parentPropertyName] = context;
+				if (prop.propertyType.meta.getProperty(this.rootPropertyName))
+					value[this.rootPropertyName] = this.rootPropertyName in context
+						? context[this.rootPropertyName]
+						: context;
+			}
+		}
+		return value;
+	}
+}
+
+describe("Back-reference properties", () => {
+	describe("from a reference property", () => {
+		function propagateRootProperty(parent: Entity, child: Entity, rootPropertyName: string = "Root") {
+			// In case the parent's Root property is not yet set, propagate when it is set
+			if (!parent[rootPropertyName])
+				parent.meta.type.getProperty(rootPropertyName).changed.subscribeOne(e => (child[rootPropertyName] = e.newValue));
+			else
+				child[rootPropertyName] = parent[rootPropertyName];
+		}
+
+		function setBackReferenceProperties(parent: Entity, child: Entity, rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
+			if (parentPropertyName in child) {
+				child[parentPropertyName] = parent;
+				propagateRootProperty(parent, child, rootPropertyName);
+			}
+			else
+				child[rootPropertyName] = parent;
+		}
+
+		function ensureChildProperties(parent: Entity, propertyName: string, rootPropertyName: string = "Root", parentPropertyName: string = "Parent"): void {
+			const value = parent.get(propertyName);
+			if (Array.isArray(value)) {
+				value.forEach(item => setBackReferenceProperties(parent, item, rootPropertyName, parentPropertyName));
+			}
+			else if (value) {
+				setBackReferenceProperties(parent, value, rootPropertyName, parentPropertyName);
+			}
+		}
+
+		let refPropModel: Model;
+		beforeEach(() => {
+			refPropModel = new Model({
+				Person: {
+					Skill: {
+						type: "Skill",
+						set: function() { return ensureChildProperties(this, "Skill"); },
+						init() {
+							return refPropModel.types["Skill"].createIfNotExists({});
+						}
+					}
+				},
+				Skill: {
+					Name: String,
+					Code: String,
+					Root: {
+						type: "Person"
+					},
+					Metadata: {
+						type: "SkillMetadata",
+						set: function() { return ensureChildProperties(this, "Metadata"); },
+						init() {
+							return refPropModel.types["SkillMetadata"].createIfNotExists({});
+						}
+					}
+				},
+				SkillMetadata: {
+					Code: {
+						type: String,
+						format: {
+							description: "AAA-000",
+							expression: /^\s*([A-Z]+)-(\d)\s*$/g,
+							message: "Code must be formatted as 'AAA-000'.",
+							reformat: "$1-$2"
+						},
+						default: {
+							dependsOn: "Parent.Code",
+							function: function() { return this.Root ? this.Root.Skill ? this.Root.Skill.Code : null : null; }
+						}
+					},
+					Root: {
+						type: "Person"
+					},
+					Parent: {
+						type: "Skill"
+					}
+				}
+			}, {
+				maxEventScopeDepth: 100,
+				maxExitingEventScopeTransferCount: 500
+			});
+
+			refPropModel.serializer.registerPropertyConverter(new IgnorePropertyConverter("Root"));
+			refPropModel.serializer.registerPropertyConverter(new IgnorePropertyConverter("Parent"));
+			refPropModel.serializer.registerPropertyConverter(new InitializeBackReferencesConverter("Root", "Parent"));
+		});
+
+		it("can be established via property initializers", async () => {
+			const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
+			const instance = await refPropModel.types.Person.create({}) as any;
+			expect(instance.Skill.Name).toBe(null);
+			expect(consoleWarn).not.toBeCalled();
+		});
+	});
+
+	describe("from a reference list property", () => {
+		let refListModel: Model;
+		beforeEach(() => {
+			refListModel = new Model({
+				Person: {
+					Skills: {
+						type: "Skill[]",
+						init() {
+							return [{ Owner: this, Name: "Skill 1" }, { Owner: this, Name: "Skill 2" }];
+						}
+					}
+				},
+				Skill: {
+					Name: String,
+					Id: {
+						type: String,
+						default() {
+							return this.meta.id;
+						}
+					},
+					Owner: {
+						type: "Person"
+					},
+					ItemNumber: {
+						type: Number,
+						default: {
+							dependsOn: "Owner.Skills",
+							function() {
+								return this.Owner ? this.Owner.Skills.indexOf(this) + 1 : -1;
+							}
+						}
+					}
+				}
+			});
+
+			refListModel.serializer.registerPropertyConverter(new IgnorePropertyConverter("Owner"));
+		});
+
+		it("can be established via property initializers", async () => {
+			const instance = await refListModel.types.Person.create({ Skills: [{ Name: "Skill 3" }, { Name: "Skill 4" }] }) as any;
+			expect(instance.serialize().Skills).toMatchObject([{ Id: "+c1", Name: "Skill 3", ItemNumber: 1 }, { Id: "+c2", Name: "Skill 4", ItemNumber: 2 }]);
+		});
+	});
+});

--- a/test/back-references.unit.ts
+++ b/test/back-references.unit.ts
@@ -54,35 +54,35 @@ class InitializeBackReferencesConverter extends PropertyConverter {
 	}
 }
 
+function propagateRootProperty(parent: Entity, child: Entity, rootPropertyName: string = "Root") {
+	// In case the parent's Root property is not yet set, propagate when it is set
+	if (!parent[rootPropertyName])
+		parent.meta.type.getProperty(rootPropertyName).changed.subscribeOne(e => (child[rootPropertyName] = e.newValue));
+	else
+		child[rootPropertyName] = parent[rootPropertyName];
+}
+
+function setBackReferenceProperties(parent: Entity, child: Entity, rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
+	if (parentPropertyName in child) {
+		child[parentPropertyName] = parent;
+		propagateRootProperty(parent, child, rootPropertyName);
+	}
+	else
+		child[rootPropertyName] = parent;
+}
+
+function ensureChildProperties(parent: Entity, propertyName: string, rootPropertyName: string = "Root", parentPropertyName: string = "Parent"): void {
+	const value = parent.get(propertyName);
+	if (Array.isArray(value)) {
+		value.forEach(item => setBackReferenceProperties(parent, item, rootPropertyName, parentPropertyName));
+	}
+	else if (value) {
+		setBackReferenceProperties(parent, value, rootPropertyName, parentPropertyName);
+	}
+}
+
 describe("Back-reference properties", () => {
 	describe("from a reference property", () => {
-		function propagateRootProperty(parent: Entity, child: Entity, rootPropertyName: string = "Root") {
-			// In case the parent's Root property is not yet set, propagate when it is set
-			if (!parent[rootPropertyName])
-				parent.meta.type.getProperty(rootPropertyName).changed.subscribeOne(e => (child[rootPropertyName] = e.newValue));
-			else
-				child[rootPropertyName] = parent[rootPropertyName];
-		}
-
-		function setBackReferenceProperties(parent: Entity, child: Entity, rootPropertyName: string = "Root", parentPropertyName: string = "Parent") {
-			if (parentPropertyName in child) {
-				child[parentPropertyName] = parent;
-				propagateRootProperty(parent, child, rootPropertyName);
-			}
-			else
-				child[rootPropertyName] = parent;
-		}
-
-		function ensureChildProperties(parent: Entity, propertyName: string, rootPropertyName: string = "Root", parentPropertyName: string = "Parent"): void {
-			const value = parent.get(propertyName);
-			if (Array.isArray(value)) {
-				value.forEach(item => setBackReferenceProperties(parent, item, rootPropertyName, parentPropertyName));
-			}
-			else if (value) {
-				setBackReferenceProperties(parent, value, rootPropertyName, parentPropertyName);
-			}
-		}
-
 		let refPropModel: Model;
 		beforeEach(() => {
 			refPropModel = new Model({

--- a/test/back-references.unit.ts
+++ b/test/back-references.unit.ts
@@ -5,6 +5,8 @@ import { Model } from "../src/model";
 import { Property } from "../src/property";
 import { isEntityType } from "../src/type";
 
+require("../src/resource-en");
+
 class IgnorePropertyConverter extends PropertyConverter {
 	readonly propertyName: string;
 	constructor(propertyName: string) {

--- a/test/back-references.unit.ts
+++ b/test/back-references.unit.ts
@@ -91,7 +91,7 @@ describe("Back-reference properties", () => {
 						type: "Skill",
 						set: function() { return ensureChildProperties(this, "Skill"); },
 						init() {
-							return refPropModel.types["Skill"].createIfNotExists({});
+							return refPropModel.types["Skill"].createIfNotExists({ Name: "Skill 1" });
 						}
 					}
 				},
@@ -143,8 +143,8 @@ describe("Back-reference properties", () => {
 		it("can be established via property initializers", async () => {
 			const consoleWarn = jest.spyOn(console, "warn").mockImplementation(() => {});
 			const instance = await refPropModel.types.Person.create({}) as any;
-			expect(instance.Skill.Name).toBe(null);
 			expect(consoleWarn).not.toBeCalled();
+			expect(instance.Skill.Name).toBe("Skill 1");
 		});
 	});
 


### PR DESCRIPTION
If properties are accessed and rules run when a property initializer is called (i.e. `init` model option), this can result in a few related problems.
- When there is a 2-way relationship between two types via properties on each type (ex: a child object that has a back-reference to its parent), then creating the child type may trigger an infinite cycle of object creation.
- Property access during initialization can cause an excessive amount of objects to be created, which can negatively impact performance or cause the browser to terminate the script.
- Property access during initialization can cause an object to be in an inconsistent state when it is ultimately introduced into the object graph, and since this is done via property "initialization", no change events will fire that could in theory get the model into a consistent state.

To avoid these problems, the initializer will instead be passed to `update` after the property's default value has been established.