### PR TITLE
Don't ignore null value in state for entity type properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- Dont' ignore null value for reference property in initial entity state
 ## [0.8.42] - 2023-01-26
 ### Fixed
 - error: "Cannot read properties of null (reading 'ready')" when using async resolver and initializers

--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -216,6 +216,8 @@ export class EntitySerializer {
 				value = data;
 			else if (data instanceof Object)
 				value = resolveEntity(ChildEntity, data);
+			else
+				value = data;
 		}
 
 		// Value List

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -4,6 +4,7 @@ import { Entity, EntityConstructorForType, isEntity } from "./entity";
 import "./resource-en";
 import { CultureInfo } from "./globalization";
 import { updateArray } from "./observable-array";
+import { Property$pendingInit } from "./property";
 
 let Types: { [name: string]: EntityConstructorForType<Entity> };
 
@@ -161,6 +162,21 @@ describe("Entity", () => {
 		it("cannot initialize constant properties", () => {
 			const person = new Types.Person({ Species: "Homo erectus" });
 			expect(person.Species).toBe("Homo sapiens");
+		});
+
+		it("cannot initialize reference properties to undefined", () => {
+			const person = Types.Person.meta.createSync({ Id: "1", Movie: undefined });
+			const movieProp = Types.Person.meta.getProperty("Movie");
+			expect(Property$pendingInit(person, movieProp)).toBe(true);
+			expect(person.Movie).toBe(null);
+			// expect(Property$pendingInit(person, movieProp)).toBe(false);
+		});
+
+		it("can initialize reference properties to null", () => {
+			const person = Types.Person.meta.createSync({ Id: "1", Movie: null });
+			const movieProp = Types.Person.meta.getProperty("Movie");
+			expect(Property$pendingInit(person, movieProp)).toBe(false);
+			expect(person.Movie).toBe(null);
 		});
 
 		it("provides a way to wait for initialization to complete", async () => {


### PR DESCRIPTION
Fixes #115 - Cannot initialize a reference property to null

> Most likely the property still is initialized to null by default, since it is the data type default. But, this is dependent on the property configuration and conceivable would not happen in some cases. It also results in the property being set to "pending init", which should not be the case since the object was explicitly provided an initial value of null for the property.