### PR TITLE
Support passing additional args to all change events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+### Changed
+- Support passing additional args to all change events
+- Allow "setting" list properties via the `property.value()` method
 ### Fixed
 - Dont' ignore null value for reference property in initial entity state
 ## [0.8.42] - 2023-01-26

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -296,7 +296,7 @@ describe("Entity", () => {
 			test("value list property", async () => {
 				const changed = jest.fn();
 				Types.Movie.meta.getProperty("Genres").changed.subscribe(changed);
-				await Types.Movie.meta.create({ Id: "1", FirstName: "Ridley", LastName: "Scott" });
+				await Types.Movie.meta.create({ Id: "1", FirstName: "Ridley", LastName: "Scott", Genres: ["fantasy"] });
 
 				expect(changed).not.toBeCalled();
 			});

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -358,9 +358,7 @@ describe("Entity", () => {
 				const property = Types.Movie.meta.getProperty("Genres");
 				const genres = instance.Genres;
 				instance.changed.subscribe(changed);
-				genres.batchUpdate(() => {
-					genres.push("fantasy");
-				});
+				property.value(instance, genres.concat(["fantasy"]));
 				expect(changed).toBeCalledWith(createEventObject({
 					entity: instance,
 					property,
@@ -381,13 +379,9 @@ describe("Entity", () => {
 				const changed = jest.fn();
 				const instance = await Types.Movie.meta.create({ Id: "1", FirstName: "Ridley", LastName: "Scott" });
 				const property = Types.Movie.meta.getProperty("Genres");
-				const genres = instance.Genres;
+				const genres = (instance as any).Genres;
 				instance.changed.subscribe(changed);
-				genres.batchUpdate(() => {
-					genres.push("fantasy");
-				}, {
-					test: 42
-				});
+				property.value(instance, genres.concat(["fantasy"]), { test: 42 });
 				expect(changed).toBeCalledWith(createEventObject({
 					entity: instance,
 					property,

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -356,15 +356,16 @@ describe("Entity", () => {
 				const changed = jest.fn();
 				const instance = await Types.Movie.meta.create({ Id: "1", FirstName: "Ridley", LastName: "Scott" });
 				const property = Types.Movie.meta.getProperty("Genres");
+				const genres = instance.Genres;
 				instance.changed.subscribe(changed);
-				instance.Genres.batchUpdate(() => {
-					instance.Genres.push("fantasy");
+				genres.batchUpdate(() => {
+					genres.push("fantasy");
 				});
 				expect(changed).toBeCalledWith(createEventObject({
 					entity: instance,
 					property,
 					newValue: expect.arrayContaining(["fantasy"]),
-					collectionChange: true,
+					collectionChanged: true,
 					changes: expect.arrayContaining([
 						{
 							type: ArrayChangeType.add,
@@ -380,9 +381,10 @@ describe("Entity", () => {
 				const changed = jest.fn();
 				const instance = await Types.Movie.meta.create({ Id: "1", FirstName: "Ridley", LastName: "Scott" });
 				const property = Types.Movie.meta.getProperty("Genres");
+				const genres = instance.Genres;
 				instance.changed.subscribe(changed);
-				instance.Genres.batchUpdate(() => {
-					instance.Genres.push("fantasy");
+				genres.batchUpdate(() => {
+					genres.push("fantasy");
 				}, {
 					test: 42
 				});
@@ -390,7 +392,7 @@ describe("Entity", () => {
 					entity: instance,
 					property,
 					newValue: expect.arrayContaining(["fantasy"]),
-					collectionChange: true,
+					collectionChanged: true,
 					changes: expect.arrayContaining([
 						{
 							type: ArrayChangeType.add,

--- a/src/helpers.unit.ts
+++ b/src/helpers.unit.ts
@@ -1,0 +1,54 @@
+import { merge } from "./helpers";
+
+describe("merge", function () {
+	it("merges two input objects into a single new object", () => {
+		var obj1 = { a: 1 };
+		var obj2 = { b: 2 };
+		var result = merge(obj1, obj2);
+
+		// Should have properties of both input objects
+		expect(result).toEqual({ a: 1, b: 2 });
+
+		// Should return a new object
+		expect(result).not.toBe(obj1);
+	});
+
+	it("returns a copy of the input objects if only one object is provided", () => {
+		var obj1 = { a: 1 };
+		var result = merge(obj1);
+
+		// Should have properties of both input objects
+		expect(result).toEqual({ a: 1 });
+
+		// Should return a new object
+		expect(result).not.toBe(obj1);
+	});
+
+	it("merges as many objects as provided", () => {
+		var obj1 = { a: 1 };
+		var obj2 = { b: 2 };
+		var obj3 = { c: 3 };
+		var obj4 = { d: 4 };
+		var result = merge(obj1, obj2, obj3, obj4);
+
+		// Should have properties of both input objects
+		expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+
+		// Should return a new object
+		expect(result).not.toBe(obj1);
+	});
+
+	it("properties of left-most input objects are overridden by subsequent input objects", () => {
+		var obj1 = { a: 1, b: 1, c: 1, d: 1 };
+		var obj2 = { b: 2, c: 2, d: 2 };
+		var obj3 = { c: 3, d: 3 };
+		var obj4 = { d: 4 };
+		var result = merge(obj1, obj2, obj3, obj4);
+
+		// Should have properties of both input objects
+		expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+
+		// Should return a new object
+		expect(result).not.toBe(obj1);
+	});
+});

--- a/src/model.unit.ts
+++ b/src/model.unit.ts
@@ -69,38 +69,44 @@ describe("settings", () => {
 });
 
 describe("Global Events", () => {
-	it("After property set", async () => {
-		const model = createModel();
-		const mockFn = jest.fn();
-		model.afterPropertySet.subscribe(mockFn);
-		const TestModel = model.getJsType("Test");
+	describe("afterPropertySet", async () => {
+		it("is called after a property set on any entity", async () => {
+			const model = createModel();
+			const mockFn = jest.fn();
+			model.afterPropertySet.subscribe(mockFn);
+			const TestModel = model.getJsType("Test");
 
-		var p = new TestModel();
-		p.PropertyOne = "test";
+			var p = new TestModel();
+			p.PropertyOne = "test";
 
-		expect(mockFn).toBeCalledWith(createEventObject({ entity: p, newValue: "test", oldValue: null, property: model.types["Test"].properties[0] }));
+			expect(mockFn).toBeCalledWith(createEventObject({ entity: p, newValue: "test", oldValue: null, property: model.types["Test"].properties[0] }));
+		});
 	});
 
-	it("Entity registered", async () => {
-		const model = createModel();
-		const mockFn = jest.fn();
-		model.entityRegistered.subscribe(mockFn);
-		const TestModel = model.getJsType("Test");
+	describe("entityRegistered", async () => {
+		it("is called when any entity is created and registered", async () => {
+			const model = createModel();
+			const mockFn = jest.fn();
+			model.entityRegistered.subscribe(mockFn);
+			const TestModel = model.getJsType("Test");
 
-		var p = new TestModel();
+			var p = new TestModel();
 
-		expect(mockFn).toBeCalledWith(createEventObject({ entity: p }));
+			expect(mockFn).toBeCalledWith(createEventObject({ entity: p }));
+		});
 	});
 
-	it("List changed", async () => {
-		const model = createModel();
-		const mockFn = jest.fn();
-		model.listChanged.subscribe(mockFn);
-		const TestModel = model.getJsType("Test");
+	describe("listChanged", async () => {
+		it("is called when a list property is changed on any entity", async () => {
+			const model = createModel();
+			const mockFn = jest.fn();
+			model.listChanged.subscribe(mockFn);
+			const TestModel = model.getJsType("Test");
 
-		var p = new TestModel();
-		p.List.push("test");
+			var p = new TestModel();
+			p.List.push("test");
 
-		expect(mockFn).toBeCalledWith(createEventObject({ entity: p, property: model.types["Test"].properties[1], newValue: p.List }));
+			expect(mockFn).toBeCalledWith(createEventObject({ entity: p, property: model.types["Test"].properties[1], newValue: p.List }));
+		});
 	});
 });

--- a/src/model.unit.ts
+++ b/src/model.unit.ts
@@ -1,5 +1,6 @@
 import { createEventObject } from "./events";
 import { Model, normalize } from "./model";
+import { ArrayChangeType } from "./observable-array";
 import "./resource-en";
 
 describe("normalize", () => {
@@ -106,7 +107,18 @@ describe("Global Events", () => {
 			var p = new TestModel();
 			p.List.push("test");
 
-			expect(mockFn).toBeCalledWith(createEventObject({ entity: p, property: model.types["Test"].properties[1], newValue: p.List }));
+			expect(mockFn).toBeCalledWith(createEventObject({
+				entity: p,
+				property: model.types["Test"].properties[1],
+				newValue: p.List,
+				collectionChanged: true,
+				changes: expect.arrayContaining([{
+					type: ArrayChangeType.add,
+					startIndex: 0,
+					endIndex: 0,
+					items: ["test"]
+				}])
+			}));
 		});
 	});
 });

--- a/src/model.unit.ts
+++ b/src/model.unit.ts
@@ -1,3 +1,4 @@
+import { Entity, EntityConstructorForType } from "./entity";
 import { createEventObject } from "./events";
 import { Model, normalize } from "./model";
 import { ArrayChangeType } from "./observable-array";
@@ -31,17 +32,17 @@ describe("normalize", () => {
 	});
 });
 
+interface Test extends Entity {
+	PropertyOne: string;
+	List: string[];
+}
+
 function createModel(config = {}) {
 	return new Model({
 		Test: {
 			PropertyOne: String,
-			List: "Test2[]"
+			List: "String[]"
 
-		},
-		Test2: {
-			Text: {
-				type: String
-			}
 		}
 	}, config);
 }
@@ -75,12 +76,26 @@ describe("Global Events", () => {
 			const model = createModel();
 			const mockFn = jest.fn();
 			model.afterPropertySet.subscribe(mockFn);
-			const TestModel = model.getJsType("Test");
+			const Test = model.getJsType("Test") as EntityConstructorForType<Test>;
 
-			var p = new TestModel();
-			p.PropertyOne = "test";
+			var entity = new Test();
+			var property = Test.meta.getProperty("PropertyOne");
+			entity.PropertyOne = "test";
 
-			expect(mockFn).toBeCalledWith(createEventObject({ entity: p, newValue: "test", oldValue: null, property: model.types["Test"].properties[0] }));
+			expect(mockFn).toBeCalledWith(createEventObject({ entity, newValue: "test", oldValue: null, property }));
+		});
+
+		it("is called with additional arguments when specified for a property change", async () => {
+			const model = createModel();
+			const mockFn = jest.fn();
+			model.afterPropertySet.subscribe(mockFn);
+			const Test = model.getJsType("Test") as EntityConstructorForType<Test>;
+
+			var entity = new Test();
+			var property = Test.meta.getProperty("PropertyOne");
+			property.value(entity, "test", { test: 42 });
+
+			expect(mockFn).toBeCalledWith(createEventObject({ entity, newValue: "test", oldValue: null, property: property, test: 42 }));
 		});
 	});
 
@@ -89,11 +104,11 @@ describe("Global Events", () => {
 			const model = createModel();
 			const mockFn = jest.fn();
 			model.entityRegistered.subscribe(mockFn);
-			const TestModel = model.getJsType("Test");
+			const Test = model.getJsType("Test") as EntityConstructorForType<Test>;
 
-			var p = new TestModel();
+			var entity = new Test();
 
-			expect(mockFn).toBeCalledWith(createEventObject({ entity: p }));
+			expect(mockFn).toBeCalledWith(createEventObject({ entity }));
 		});
 	});
 
@@ -102,15 +117,16 @@ describe("Global Events", () => {
 			const model = createModel();
 			const mockFn = jest.fn();
 			model.listChanged.subscribe(mockFn);
-			const TestModel = model.getJsType("Test");
+			const Test = model.getJsType("Test") as EntityConstructorForType<Test>;
 
-			var p = new TestModel();
-			p.List.push("test");
+			var entity = new Test();
+			var property = Test.meta.getProperty("List");
+			entity.List.push("test");
 
 			expect(mockFn).toBeCalledWith(createEventObject({
-				entity: p,
-				property: model.types["Test"].properties[1],
-				newValue: p.List,
+				entity,
+				property,
+				newValue: entity.List,
 				collectionChanged: true,
 				changes: expect.arrayContaining([{
 					type: ArrayChangeType.add,
@@ -118,6 +134,31 @@ describe("Global Events", () => {
 					endIndex: 0,
 					items: ["test"]
 				}])
+			}));
+		});
+
+		it("is called with additional arguments when specified for a list change", async () => {
+			const model = createModel();
+			const mockFn = jest.fn();
+			model.listChanged.subscribe(mockFn);
+			const Test = model.getJsType("Test") as EntityConstructorForType<Test>;
+
+			var entity = new Test();
+			var property = Test.meta.getProperty("List");
+			property.value(entity, entity.List.concat(["test"]), { test: 42 });
+
+			expect(mockFn).toBeCalledWith(createEventObject({
+				entity,
+				property,
+				newValue: entity.List,
+				collectionChanged: true,
+				changes: expect.arrayContaining([{
+					type: ArrayChangeType.add,
+					startIndex: 0,
+					endIndex: 0,
+					items: ["test"]
+				}]),
+				test: 42
 			}));
 		});
 	});

--- a/src/observable-array.ts
+++ b/src/observable-array.ts
@@ -11,7 +11,7 @@ export interface ObservableArray<ItemType> extends Array<ItemType> {
 	/**
 	 * Begin queueing changes to the array, make changes in the given callback function, then stop queueing and raise events
 	 */
-	batchUpdate(fn: (array: ObservableArray<ItemType>) => void): void;
+	batchUpdate(fn: (array: ObservableArray<ItemType>) => void, additionalArgs?: any): void;
 
 }
 
@@ -214,7 +214,7 @@ export class ObservableArrayImplementation<ItemType> extends Array<ItemType> imp
 	/**
 	 * Begin queueing changes to the array, make changes in the given callback function, then stop queueing and raise events
 	 */
-	batchUpdate(fn: (array: ObservableArray<ItemType>) => void, additionalArgs?: any): void {
+	batchUpdate(fn: (array: ObservableArray<ItemType>) => void, additionalArgs: any = null): void {
 		ObservableArray$batchUpdate.call(this, fn, additionalArgs);
 	}
 
@@ -338,7 +338,7 @@ export function ObservableArray$overrideNativeMethods<ItemType>(this: ItemType[]
 /**
  * Begin queueing changes to the array, make changes in the given callback function, then stop queueing and raise events
  */
-export function ObservableArray$batchUpdate<ItemType>(this: ObservableArray<ItemType>, fn: (array: ObservableArray<ItemType>) => void, additionalArgs?: any): void {
+export function ObservableArray$batchUpdate<ItemType>(this: ObservableArray<ItemType>, fn: (array: ObservableArray<ItemType>) => void, additionalArgs: any = null): void {
 	this.__aob__.startQueueingChanges();
 	try {
 		fn(this);

--- a/src/observable-array.unit.ts
+++ b/src/observable-array.unit.ts
@@ -1,4 +1,5 @@
-import { ObservableArray, updateArray } from "./observable-array";
+import { createEventObject } from "./events";
+import { ArrayChangeType, ObservableArray, updateArray } from "./observable-array";
 
 describe("ObservableArray", () => {
 	it("should not publish change event for no changes", () => {
@@ -7,5 +8,194 @@ describe("ObservableArray", () => {
 		arr.changed.subscribe(changeHandler);
 		arr.batchUpdate(() => updateArray(arr, []));
 		expect(changeHandler).not.toBeCalled();
+	});
+	describe("copyWithin", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/copyWithin
+		it("shallow copies part of an array to another location in the same array and returns it without modifying its length", () => {
+			const arr = ObservableArray.create(["a", "b", "c", "d", "e"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			arr.copyWithin(0, 3, 4);
+			expect(arr).toEqual(["d", "b", "c", "d", "e"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.replace,
+						startIndex: 3,
+						endIndex: 4
+					}
+				]
+			}));
+		});
+	});
+	describe("fill", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/fill
+		it("changes elements in an array to a static value", () => {
+			const arr = ObservableArray.create([1, 2, 3, 4]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			arr.fill(0, 2, 4);
+			expect(arr).toEqual([1, 2, 0, 0]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.replace,
+						startIndex: 2,
+						endIndex: 4
+					}
+				]
+			}));
+		});
+	});
+	describe("pop", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop
+		it("removes the last element from an array and returns that element", () => {
+			const arr = ObservableArray.create(["broccoli", "cauliflower", "cabbage", "kale", "tomato"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var result = arr.pop();
+			expect(result).toBe("tomato");
+			expect(arr).toEqual(["broccoli", "cauliflower", "cabbage", "kale"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.remove,
+						startIndex: 4,
+						endIndex: 4,
+						items: ["tomato"]
+					}
+				]
+			}));
+		});
+	});
+	describe("push", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/push
+		it("adds the specified elements to the end of an array and returns the new length of the array", () => {
+			const arr = ObservableArray.create(["pigs", "goats", "sheep"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var result = arr.push("cows");
+			expect(result).toBe(4);
+			expect(arr).toEqual(["pigs", "goats", "sheep", "cows"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.add,
+						startIndex: 3,
+						endIndex: 3,
+						items: ["cows"]
+					}
+				]
+			}));
+		});
+	});
+	describe("reverse", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reverse
+		it("reverses an array in place and returns the reference to the same array", () => {
+			const arr = ObservableArray.create(["one", "two", "three"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var reversed = arr.reverse();
+			expect(reversed).toBe(arr);
+			expect(arr).toEqual(["three", "two", "one"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.reorder,
+						startIndex: 0,
+						endIndex: 2
+					}
+				]
+			}));
+		});
+	});
+	describe("shift", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift
+		it("removes the first element from an array and returns that removed element", () => {
+			const arr = ObservableArray.create([1, 2, 3]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var result = arr.shift();
+			expect(result).toBe(1);
+			expect(arr).toEqual([2, 3]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.remove,
+						startIndex: 0,
+						endIndex: 0,
+						items: [1]
+					}
+				]
+			}));
+		});
+	});
+	describe("sort", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+		it("sorts the elements of an array in place and returns the reference to the same array, now sorted", () => {
+			const arr = ObservableArray.create(["March", "Jan", "Feb", "Dec"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var arr2 = arr.sort();
+			expect(arr2).toBe(arr);
+			expect(arr).toEqual(["Dec", "Feb", "Jan", "March"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.reorder,
+						startIndex: 0,
+						endIndex: 3
+					}
+				]
+			}));
+		});
+	});
+	describe("splice", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice
+		it("changes the contents of an array by removing or replacing existing elements and/or adding new elements in place", () => {
+			const arr = ObservableArray.create(["Jan", "Feb", "March", "April", "June"]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var removed = arr.splice(4, 1, "May");
+			expect(removed).toEqual(["June"]);
+			expect(arr).toEqual(["Jan", "Feb", "March", "April", "May"]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.remove,
+						startIndex: 4,
+						endIndex: 4,
+						items: ["June"]
+					},
+					{
+						type: ArrayChangeType.add,
+						startIndex: 4,
+						endIndex: 4,
+						items: ["May"]
+					}
+				]
+			}));
+		});
+	});
+	describe("unshift", () => {
+		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/unshift
+		it("adds the specified elements to the beginning of an array and returns the new length of the array", () => {
+			const arr = ObservableArray.create([1, 2, 3]);
+			const changeHandler = jest.fn();
+			arr.changed.subscribe(changeHandler);
+			var result = arr.unshift(4, 5);
+			expect(result).toBe(5);
+			expect(arr).toEqual([4, 5, 1, 2, 3]);
+			expect(changeHandler).toBeCalledWith(createEventObject({
+				changes: [
+					{
+						type: ArrayChangeType.add,
+						startIndex: 0,
+						endIndex: 1,
+						items: [4, 5]
+					}
+				]
+			}));
+		});
 	});
 });

--- a/src/observable-array.unit.ts
+++ b/src/observable-array.unit.ts
@@ -4,6 +4,7 @@ describe("ObservableArray", () => {
 	it("should not publish change event for no changes", () => {
 		const arr = ObservableArray.create([]);
 		const changeHandler = jest.fn();
+		arr.changed.subscribe(changeHandler);
 		arr.batchUpdate(() => updateArray(arr, []));
 		expect(changeHandler).not.toBeCalled();
 	});

--- a/src/property.ts
+++ b/src/property.ts
@@ -999,9 +999,6 @@ function Property$shouldSetValue(property: Property, obj: Entity, old: any, val:
 	if (property.isConstant) {
 		throw new Error("Constant properties cannot be modified.");
 	}
-	else if (property.isList) {
-		throw new Error("Property set on lists is not permitted.");
-	}
 	else {
 		// compare values so that this check is accurate for primitives
 		var oldValue = (old === undefined || old === null) ? old : old.valueOf();

--- a/src/property.ts
+++ b/src/property.ts
@@ -1017,7 +1017,7 @@ function Property$setValue(property: Property, obj: Entity, currentValue: any, n
 		let currentArray = currentValue as ObservableArray<any>;
 		currentArray.batchUpdate((array) => {
 			updateArray(array, newValue);
-		});
+		}, additionalArgs);
 	}
 	else {
 		let oldValue = currentValue;

--- a/src/property.ts
+++ b/src/property.ts
@@ -1014,7 +1014,7 @@ function Property$shouldSetValue(property: Property, obj: Entity, old: any, val:
 	}
 }
 
-function Property$setValue(property: Property, obj: Entity, currentValue: any, newValue: any, additionalArgs: any = {}): void {
+function Property$setValue(property: Property, obj: Entity, currentValue: any, newValue: any, additionalArgs: any = null): void {
 	// Update lists as batch remove/add operations
 	if (property.isList) {
 		let currentArray = currentValue as ObservableArray<any>;

--- a/src/property.ts
+++ b/src/property.ts
@@ -891,10 +891,7 @@ export function Property$pendingInit(obj: Entity, prop: Property, value: boolean
 
 function Property$subArrayEvents(obj: Entity, property: Property, array: ObservableArray<any>): void {
 	array.changed.subscribe(function (args) {
-		// NOTE: property change should be broadcast before rules are run so that if
-		// any rule causes a roundtrip to the server these changes will be available
-		// TODO: Implement notifyListChanged?
-		// property.containingType.model.notifyListChanged(target, property, changes);
+		// Don't raise a no-op list change event
 		if (!args.changes.length)
 			return;
 

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -1,5 +1,7 @@
 /* eslint-disable no-new */
+import { createEventObject } from "./events";
 import { Model } from "./model";
+import { ArrayChangeType } from "./observable-array";
 
 describe("Property", () => {
 	it("can have a constant value", async () => {
@@ -157,6 +159,178 @@ describe("Property", () => {
 			it("does nothing if already initialized", async () => {
 				const instance = await refListModel.types.Person.create({ Skills: [] }) as any;
 				expect(instance.serialize().Skills).toMatchObject([]);
+			});
+		});
+	});
+
+	describe("change event", () => {
+		describe("value property", () => {
+			let valuePropModel: Model;
+
+			beforeEach(() => {
+				valuePropModel = new Model({
+					Person: {
+						Name: {
+							type: String,
+							init() {
+								return "Test";
+							}
+						}
+					}
+				});
+			});
+
+			it("is raised when the property is changed", async () => {
+				const instance = await valuePropModel.types.Person.create({}) as any;
+				expect(instance.Name).toBe("Test");
+				const property = valuePropModel.types.Person.getProperty("Name");
+				const changeHandler = jest.fn();
+				property.changed.subscribe(changeHandler);
+				await instance.update({ Name: "John" });
+				expect(instance.Name).toBe("John");
+				expect(changeHandler).toBeCalledWith(createEventObject({
+					entity: instance,
+					property,
+					newValue: "John",
+					oldValue: "Test"
+				}));
+			});
+		});
+
+		describe("value list property", () => {
+			let valueListModel: Model;
+			beforeEach(() => {
+				valueListModel = new Model({
+					Person: {
+						Skills: {
+							type: "String[]",
+							init() {
+								return ["X", "Y"];
+							}
+						}
+					}
+				});
+			});
+
+			it("is raised when the list is changed", async () => {
+				const instance = await valueListModel.types.Person.create({}) as any;
+				expect(instance.serialize().Skills).toEqual(["X", "Y"]);
+				const property = valueListModel.types.Person.getProperty("Skills");
+				const changeHandler = jest.fn();
+				property.changed.subscribe(changeHandler);
+				instance.Skills.splice(1, 1, "Z");
+				expect(instance.Skills.slice()).toEqual(["X", "Z"]);
+				expect(changeHandler).toBeCalledWith(
+					expect.objectContaining({
+						entity: instance,
+						property,
+						newValue: expect.arrayContaining(["X", "Z"]),
+						collectionChanged: true,
+						changes: expect.arrayContaining([
+							{
+								type: ArrayChangeType.remove,
+								startIndex: 1,
+								endIndex: 1,
+								items: ["Y"]
+							},
+							{
+								type: ArrayChangeType.add,
+								startIndex: 1,
+								endIndex: 1,
+								items: ["Z"]
+							}
+						])
+					})
+				);
+			});
+		});
+
+		describe("reference property", () => {
+			let refPropModel: Model;
+			beforeEach(() => {
+				refPropModel = new Model({
+					Person: {
+						Skill: {
+							type: "Skill",
+							init() {
+								return { Name: "Skill 1" };
+							}
+						}
+					},
+					Skill: { Name: String }
+				});
+			});
+
+			it("is raised when the property is changed", async () => {
+				const instance = await refPropModel.types.Person.create({}) as any;
+				const skill1 = instance.Skill;
+				expect(instance.Skill).not.toBeNull();
+				expect(instance.Skill.Name).toBe("Skill 1");
+				const property = refPropModel.types.Person.getProperty("Skill");
+				const changeHandler = jest.fn();
+				property.changed.subscribe(changeHandler);
+				const skill2 = await refPropModel.types.Skill.create({ Name: "Skill 2" }) as any;
+				await instance.update({ Skill: skill2 });
+				expect(instance.Skill).toBe(skill2);
+				expect(instance.Skill.Name).toBe("Skill 2");
+				expect(changeHandler).toBeCalledWith(createEventObject({
+					entity: instance,
+					property,
+					newValue: skill2,
+					oldValue: skill1
+				}));
+			});
+		});
+
+		describe("reference list property", () => {
+			let refListModel: Model;
+			beforeEach(() => {
+				refListModel = new Model({
+					Person: {
+						Skills: {
+							type: "Skill[]",
+							init() {
+								return [{ Name: "Skill 1" }, { Name: "Skill 2" }];
+							}
+						}
+					},
+					Skill: { Name: String }
+				});
+			});
+
+			it("is raised when the list is changed", async () => {
+				const instance = await refListModel.types.Person.create({}) as any;
+				expect(instance.serialize().Skills).toEqual([{ Name: "Skill 1" }, { Name: "Skill 2" }]);
+				const skill1 = instance.Skills[0];
+				const skill2 = instance.Skills[1];
+				const property = refListModel.types.Person.getProperty("Skills");
+				const changeHandler = jest.fn();
+				property.changed.subscribe(changeHandler);
+				const skill0 = await refListModel.types.Skill.create({ Name: "Skill 0" }) as any;
+				instance.Skills.splice(0, 2, skill0);
+				expect(instance.serialize().Skills).toEqual([{ Name: "Skill 0" }]);
+				expect(changeHandler).toBeCalledWith(
+					expect.objectContaining({
+						entity: instance,
+						property,
+						newValue: expect.arrayContaining([skill0]),
+						collectionChanged: true,
+						changes: expect.arrayContaining([
+							{
+								type: ArrayChangeType.remove,
+								startIndex: 0,
+								endIndex: 1,
+								items: expect.arrayContaining([skill1, skill2])
+							},
+							{
+								type: ArrayChangeType.add,
+								startIndex: 0,
+								endIndex: 0,
+								items: expect.arrayContaining([skill0])
+							}
+						])
+					})
+				);
 			});
 		});
 	});


### PR DESCRIPTION
Previously, `additionalArgs` were only supported for the `property.changed` event. Also include `additionalArgs` in the `model.afterPropertySet` / `model.listChanged` and `entity.changed` events. Also, update `ObservableList` to support `additionalArgs` via `batchUpdate`, and pass along from property setter.

Also, allow setting list properties (i.e. via `property.value()` method). This was supported (it calls `updateArray` within a `batchUpdate` call), so there's no reason to prohibit it.

Fixes #116 - Additional args when setting a property value are not included in all events