### PR TITLE
Remove duplicate exports of 'initilization-context'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Allow "setting" list properties via the `property.value()` method
 ### Fixed
 - Dont' ignore null value for reference property in initial entity state
+- Remove duplicate exports of 'initilization-context'
 ## [0.8.42] - 2023-01-26
 ### Fixed
 - error: "Cannot read properties of null (reading 'ready')" when using async resolver and initializers

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ export * from "./property-path";
 export * from "./entity";
 export * from "./object-meta";
 export * from "./format";
-export * from "./initilization-context";
 export * from "./observable-array";
 
 // Conditions, etc.


### PR DESCRIPTION
The "initialization-context" module is imported / exported multiple times. Removed the duplicate, leaving the one under the "serialization" heading.