### PR TITLE
Ignore invalid data for reference properties

### DIFF
--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -216,7 +216,7 @@ export class EntitySerializer {
 				value = data;
 			else if (data instanceof Object)
 				value = resolveEntity(ChildEntity, data);
-			else
+			else if (data === null)
 				value = data;
 		}
 

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -170,7 +170,7 @@ describe("Entity", () => {
 			const movieProp = Types.Person.meta.getProperty("Movie");
 			expect(Property$pendingInit(person, movieProp)).toBe(true);
 			expect(person.Movie).toBe(null);
-			// expect(Property$pendingInit(person, movieProp)).toBe(false);
+			expect(person.serialize()).toEqual({ Address: null, FirstName: null, Id: "1", LastName: null, Movie: null, Salary: null });
 		});
 
 		it("can initialize reference properties to null", () => {
@@ -178,6 +178,15 @@ describe("Entity", () => {
 			const movieProp = Types.Person.meta.getProperty("Movie");
 			expect(Property$pendingInit(person, movieProp)).toBe(false);
 			expect(person.Movie).toBe(null);
+			expect(person.serialize()).toEqual({ Address: null, FirstName: null, Id: "1", LastName: null, Movie: null, Salary: null });
+		});
+
+		it("invalid data for reference properties is ignored", () => {
+			const person = Types.Person.meta.createSync({ Id: "1", Movie: "Toy Story" });
+			const movieProp = Types.Person.meta.getProperty("Movie");
+			expect(Property$pendingInit(person, movieProp)).toBe(true);
+			expect(person.Movie).toBe(null);
+			expect(person.serialize()).toEqual({ Address: null, FirstName: null, Id: "1", LastName: null, Movie: null, Salary: null });
 		});
 
 		it("provides a way to wait for initialization to complete", async () => {


### PR DESCRIPTION
A recent change was made to no longer ignore a `null` in initial state for a reference property. However, the change was too lax and allowed invalid data to be stored for reference properties in some cases (ex: a `string`). This would cause a downstream error when attempting to serialize the object.

**_Fix:_** Aside from entities and POJO object data, only allow `null` values for entity properties. Undefined and any invalid data will be ignored.

This masks an underlying problem in that invalid data is silently ignored when deserializing, but this was existing behavior and changing that is technically a breaking change. This should be revisited and changed in a major or minor version update along with corresponding downstream changes to account for the change.