### PR TITLE
TypeScript type enhancements and test fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,6 @@
         "bin/": true,
         "obj/": true,
         "dist/": true,
+        "**/*.bak": true,
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Fixed
+- Check `isList` when determining whether to create a list-length or string-length rule.
+- typing: Allow `message` and `error` functions to return `null` or `undefined`.
+### Changed
+- Add `EntityType` generic type arguments to various types
+### Added
+- Add `EntityOfType` generic type.
 ## [0.8.44] - 2023-06-12
 ### Fixed
 - Ignore undefined or invalid value for reference property in initial entity state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - typing: Allow `message` and `error` functions to return `null` or `undefined`.
 - Avoid incorrect TS error because `$namespace` option is an object that does not already contain the model's types.
 ### Changed
-- Add `EntityType` generic type arguments to various types
+- Add `TEntity` generic type arguments to various types
 - Rename `ValueType` -> `ValueConstructor`
 - Removed `EntityType` type alias (use `EntityConstructor` or `EntityConstructorForType` instead)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 - Check `isList` when determining whether to create a list-length or string-length rule.
 - typing: Allow `message` and `error` functions to return `null` or `undefined`.
+- Avoid incorrect TS error because `$namespace` option is an object that does not already contain the model's types.
 ### Changed
 - Add `EntityType` generic type arguments to various types
+- Rename `ValueType` -> `ValueConstructor`
+- Removed `EntityType` type alias (use `EntityConstructor` or `EntityConstructorForType` instead)
 ### Added
-- Add `EntityOfType` generic type.
+- Add generic types: `EntityOfType`, `ObjectMetaOfType`, `TypeOfType`, etc.
+- Add `Model.create` method with better type checking and inferencing.
 ## [0.8.45] - 2023-11-21
 ### Changed
 - Use `Object.defineProperty` for fields of `Entity` and `ObjectMeta`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "type-check": "tsc --noEmit",
     "type-check:watch": "npm run type-check -- --watch",
-    "build:typescript": "tsc",
+    "build:typescript": "rimraf ./@types && rimraf ./lib && tsc",
     "build:esm": "tsc --target es5 --outDir ./esm --module ES2015",
     "build:webpack": "webpack --mode=production",
     "build": "npm run build:typescript && npm run build:esm && npm run build:webpack",

--- a/src/allowed-values-rule.unit.ts
+++ b/src/allowed-values-rule.unit.ts
@@ -1,31 +1,14 @@
-import { TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { createModel } from "./model";
 
 import "./resource-en";
 
-function createModel(options: ModelOptions) {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("AllowedValuesRule", () => {
 	test("Prevent the setting of value if value is not in allowedValues list.", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Choice: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await createModel<{
+			Test: {
+				Choice: string;
+			}
+		}>({
 			Test: {
 				Choice: {
 					allowedValues: {
@@ -37,7 +20,7 @@ describe("AllowedValuesRule", () => {
 				}
 			}
 		});
-		var t = new Types.Test({ Choice: "First" });
+		var t = new Test({ Choice: "First" });
 		try {
 			t.Choice = "Second";
 			expect(t.Choice).toBe("Second");

--- a/src/allowed-values-rule.unit.ts
+++ b/src/allowed-values-rule.unit.ts
@@ -1,8 +1,9 @@
-import { Model } from "./model";
+import { TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 import "./resource-en";
 
-function createModel(options) {
+function createModel(options: ModelOptions) {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -13,7 +14,18 @@ function createModel(options) {
 
 describe("AllowedValuesRule", () => {
 	test("Prevent the setting of value if value is not in allowedValues list.", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Choice: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Choice: {
 					allowedValues: {
@@ -24,9 +36,8 @@ describe("AllowedValuesRule", () => {
 					type: String
 				}
 			}
-		}) as any;
-		const Test = model.getJsType("Test");
-		var t = new Test({ Choice: "First" });
+		});
+		var t = new Types.Test({ Choice: "First" });
 		try {
 			t.Choice = "Second";
 			expect(t.Choice).toBe("Second");

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -1,4 +1,4 @@
-import { TEntityConstructor } from "./entity";
+import { EntityOfType, TEntityConstructor } from "./entity";
 import { Model, ModelOptions } from "./model";
 
 import "./resource-en";
@@ -198,15 +198,29 @@ describe("CalculateRule", () => {
 	});
 
 	describe("calculated list", () => {
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Id: string;
+			Len: number;
+			Max: number;
+			Nums: number[];
+		};
+
 		let model;
 		beforeEach(() => {
 			model = new Model({
+				$namespace: Types as any,
 				Test: {
 					Id: { identifier: true, type: String },
 					Len: {
 						type: Number,
 						default: {
-							function() {
+							function(this: EntityOfType<Test>) {
 								return this.Nums.length;
 							},
 							dependsOn: "Nums"

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -14,7 +14,7 @@ function createModel(options: ModelOptions & ModelNamespaceOption & ModelLocaliz
 
 describe("CalculateRule", () => {
 	test("Errors thrown in calculated rules are displayed to the user.", async () => {
-		let consoleOutputs = [];
+		let consoleOutputs: any[] = [];
 		window.console.warn = jest.fn((s)=> consoleOutputs.push(s.toString()));
 		const model = await createModel({
 			Test: {
@@ -189,7 +189,7 @@ describe("CalculateRule", () => {
 						type: "Number[]",
 						get: {
 							function() {
-								const list = [];
+								const list: any[] = [];
 								for (let i = 0; i < this.Max; i++)
 									list.push(i+1);
 								return list;

--- a/src/calculated-property-rule.unit.ts
+++ b/src/calculated-property-rule.unit.ts
@@ -1,7 +1,7 @@
 import { Model, ModelLocalizationOptions, ModelNamespaceOption, ModelOptions } from "./model";
 
 import "./resource-en";
-import { EntityType, Type } from "./type";
+import { ReferenceType, Type } from "./type";
 
 function createModel(options: ModelOptions & ModelNamespaceOption & ModelLocalizationOptions) {
 	return new Promise<Model>((resolve) => {
@@ -91,7 +91,7 @@ describe("CalculateRule", () => {
 					}
 				}
 			});
-			TestEntity = (model.getJsType("Test") as EntityType).meta;
+			TestEntity = (model.getJsType("Test") as ReferenceType).meta;
 		});
 
 		describe("on new instance", () => {

--- a/src/condition-rule.ts
+++ b/src/condition-rule.ts
@@ -10,7 +10,7 @@ export class ConditionRule extends Rule {
 	assert: (this: Entity) => boolean;
 
 	// The message describing the state of the condition
-	message: string | ((this: Entity) => string);
+	message: string | ((this: Entity) => string | null | undefined);
 
 	// Array of property paths the validation condition should be attached to when asserted, in addition to the target property
 	properties: PropertyPath[];
@@ -83,7 +83,7 @@ export interface ConditionRuleOptions extends RuleOptions {
 	assert?: (this: Entity) => boolean;
 
 	// the message to show the user when the validation fails
-	message?: string | ((this: Entity) => string);
+	message?: string | ((this: Entity) => string | null | undefined);
 
 	// an array of property paths the validation condition should be attached to when asserted, in addition to the target property
 	properties?: PropertyPath[];

--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -192,7 +192,7 @@ export class EntitySerializer {
 
 		let value: any;
 
-		const resolveEntity = (type: EntityConstructorForType<Entity>, state: any) => {
+		const resolveEntity = <T>(type: EntityConstructorForType<T>, state: any) => {
 			let entity: Entity;
 			let id: any = type.meta.identifier ? state[type.meta.identifier.name] : null;
 			if (id)

--- a/src/entity-serializer.ts
+++ b/src/entity-serializer.ts
@@ -163,8 +163,8 @@ export class EntitySerializer {
 	 * Produces a JSON-valid object representation of the entity.
 	 * @param entity
 	 */
-	serialize(entity: Entity, settings: SerializationSettings = DefaultSerializationSettings): object {
-		let result: object = {};
+	serialize(entity: Entity, settings: SerializationSettings = DefaultSerializationSettings): Record<string, any> {
+		let result: Record<string, unknown> = {};
 		const type = entity.meta.type;
 		flatMap(this.getPropertyInjectors(type), i => i.inject(entity))
 			.concat(type.properties
@@ -175,7 +175,7 @@ export class EntitySerializer {
 					if (result.hasOwnProperty(pair.key))
 						throw new Error(`Property '${pair.key}' was encountered twice during serialization. Make sure injected properties do not collide with model properties.`);
 
-					(result as any)[pair.key] = pair.value;
+					result[pair.key] = pair.value;
 				}
 			});
 		return result;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -384,7 +384,7 @@ export class Entity {
 	}
 }
 
-export type EntityPropertiesOfType<T> = {
+export type EntityDynamicPropertiesOfType<T> = {
     [P in keyof T]:
 		T[P] extends (infer TItem)[]
 			? ObservableArray<(
@@ -410,7 +410,7 @@ export interface TEntity<T> extends Entity {
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgsForType<T>>;
 }
 
-export type EntityOfType<T> = TEntity<T> & EntityPropertiesOfType<T>;
+export type EntityOfType<T> = TEntity<T> & EntityDynamicPropertiesOfType<T>;
 
 export type EntityConstructorForType<T> = {
     new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -5,7 +5,7 @@ import { InitializationContext } from "./initilization-context";
 import { ObjectMeta, ObjectMetaOfType } from "./object-meta";
 import { Property, Property$init, Property$pendingInit, Property$setter } from "./property";
 import { ObjectLookup, entries } from "./helpers";
-import { DefaultSerializationSettings } from "./entity-serializer";
+import { DefaultSerializationSettings, SerializationSettings } from "./entity-serializer";
 import { ObservableArray } from "./observable-array";
 
 export class Entity {
@@ -353,7 +353,7 @@ export class Entity {
 	 * Produces a JSON-valid object representation of the entity.
 	 * @param entity
 	 */
-	serialize(settings = DefaultSerializationSettings): object {
+	serialize(settings = DefaultSerializationSettings): Record<string, any> {
 		return this.serializer.serialize(this, settings);
 	}
 
@@ -407,6 +407,7 @@ export interface EntityBasePropertiesOfType<T> {
 	meta: ObjectMetaOfType<T>;
 	update(property: string, value?: any): Promise<void>;
 	update(args: EntityArgsOfType<T>): Promise<void>;
+	serialize(settings?: SerializationSettings): T;
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgsForType<T>>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgsForType<T>>;
 }

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -188,6 +188,7 @@ export class Entity {
 	}
 
 	update(properties: ObjectLookup<any>): Promise<void>;
+	update(property: string, value: any): Promise<void>;
 	update(property: any, value?: any): Promise<void> {
 		let properties: ObjectLookup<any>;
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -2,7 +2,7 @@ import { Event, EventObject, EventSubscriber } from "./events";
 import { Format } from "./format";
 import { Type, EntityType, isEntityType, getIdFromState, TypeOfType } from "./type";
 import { InitializationContext } from "./initilization-context";
-import { ObjectMeta } from "./object-meta";
+import { ObjectMeta, ObjectMetaOfType } from "./object-meta";
 import { Property, Property$init, Property$pendingInit, Property$setter } from "./property";
 import { ObjectLookup, entries } from "./helpers";
 import { DefaultSerializationSettings } from "./entity-serializer";
@@ -187,7 +187,6 @@ export class Entity {
 	}
 
 	update(properties: ObjectLookup<any>): Promise<void>;
-	update(property: string, value: any): Promise<void>;
 	update(property: any, value?: any): Promise<void> {
 		let properties: ObjectLookup<any>;
 
@@ -403,11 +402,14 @@ export type EntityPropertiesOfType<T> = {
 			) | null;
 };
 
-type EntityOfTypeMemberOverrides<T> = {
-    update(args: EntityArgsOfType<T>): Promise<void>;
-};
+export interface TEntity<T> extends Entity {
+	meta: ObjectMetaOfType<T>;
+	update(args: EntityArgsOfType<T>): Promise<void>;
+	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgs<EntityOfType<T>>>;
+	readonly changed: EventSubscriber<Entity, EntityChangeEventArgs<EntityOfType<T>>>;
+}
 
-export type EntityOfType<T> = EntityPropertiesOfType<T> & EntityOfTypeMemberOverrides<T> & Entity; // Omit<Entity, keyof EntityOfTypeMemberOverrides<T>> & ;
+export type EntityOfType<T> = TEntity<T> & EntityPropertiesOfType<T>;
 
 export type TEntityConstructor<T> = {
     new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -390,12 +390,14 @@ export type EntityPropertiesOfType<T> = {
 			? ObservableArray<(
 				TItem extends string ? string :
 				TItem extends number ? number :
+				TItem extends boolean ? boolean :
 				TItem extends Date ? Date :
 				EntityOfType<TItem>
 			)>
 			: (
 				T[P] extends string ? string :
 				T[P] extends number ? number :
+				T[P] extends boolean ? boolean :
 				T[P] extends Date ? Date :
 				EntityOfType<T[P]>
 			) | null;
@@ -419,12 +421,14 @@ export type EntityArgsOfType<T> = Partial<{
 			? (
 				TItem extends string ? string[] :
 				TItem extends number ? number[] :
+				TItem extends boolean ? boolean[] :
 				TItem extends Date ? Date[] :
 				(EntityOfType<TItem> | Partial<EntityArgsOfType<TItem>>)[]
 			)
 			: (
 				T[P] extends string ? string :
 				T[P] extends number ? number :
+				T[P] extends boolean ? boolean :
 				T[P] extends Date ? Date :
 				(EntityOfType<T[P]> | Partial<EntityArgsOfType<T[P]>>)
 			) | null;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -388,9 +388,9 @@ export interface EntityConstructor {
 	new(properties?: ObjectLookup<any>): Entity; // Construct new instance with state
 }
 
-export interface EntityConstructorForType<TEntity extends Entity> extends EntityConstructor {
-	new(): TEntity;
-	new(properties?: ObjectLookup<any>): TEntity; // Construct new instance with state
+export interface EntityConstructorForType<EntityType extends Entity> extends EntityConstructor {
+	new(): EntityType;
+	new(properties?: ObjectLookup<any>): EntityType; // Construct new instance with state
 	meta: Type;
 }
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,6 @@
 import { Event, EventObject, EventSubscriber } from "./events";
 import { Format } from "./format";
-import { Type, EntityType, isEntityType, getIdFromState, TypeOfType } from "./type";
+import { Type, isEntityType, getIdFromState, TypeOfType } from "./type";
 import { InitializationContext } from "./initilization-context";
 import { ObjectMeta, ObjectMetaOfType } from "./object-meta";
 import { Property, Property$init, Property$pendingInit, Property$setter } from "./property";
@@ -330,7 +330,7 @@ export class Entity {
 		// Get the entity format to use
 		let formatter: Format<Entity> = null;
 		if (format) {
-			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format, formatEval);
+			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityConstructor, format, formatEval);
 		}
 		else {
 			formatter = this.meta.type.format;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,6 @@
 import { Event, EventObject, EventSubscriber } from "./events";
 import { Format } from "./format";
-import { Type, ReferenceType, isEntityType, getIdFromState, TypeOfType } from "./type";
+import { Type, EntityType, isEntityType, getIdFromState, TypeOfType } from "./type";
 import { InitializationContext } from "./initilization-context";
 import { ObjectMeta } from "./object-meta";
 import { Property, Property$init, Property$pendingInit, Property$setter } from "./property";
@@ -330,7 +330,7 @@ export class Entity {
 		// Get the entity format to use
 		let formatter: Format<Entity> = null;
 		if (format) {
-			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as ReferenceType, format, formatEval);
+			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format, formatEval);
 		}
 		else {
 			formatter = this.meta.type.format;
@@ -423,14 +423,14 @@ export type EntityArgsOfType<T> = Partial<{
 				TItem extends number ? number[] :
 				TItem extends boolean ? boolean[] :
 				TItem extends Date ? Date[] :
-				(EntityOfType<TItem> | Partial<EntityArgsOfType<TItem>>)[]
+				(EntityOfType<TItem> | EntityArgsOfType<TItem>)[]
 			)
 			: (
 				T[P] extends string ? string :
 				T[P] extends number ? number :
 				T[P] extends boolean ? boolean :
 				T[P] extends Date ? Date :
-				(EntityOfType<T[P]> | Partial<EntityArgsOfType<T[P]>>)
+				(EntityOfType<T[P]> | EntityArgsOfType<T[P]>)
 			) | null;
 }>;
 

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -432,8 +432,19 @@ export type EntityArgsOfType<T> = Partial<{
 }>;
 
 export interface EntityConstructor {
+	/**
+	 * Construct a new instance with no initial state specified
+	 */
 	new(): Entity;
-	new(properties?: ObjectLookup<any>): Entity; // Construct new instance with state
+	/**
+	 * Construct an existing instance with persisted state
+	 */
+	new(id: string, args?: ObjectLookup<any>): Entity;
+	/**
+	 * Construct a new instance with initial state
+	 */
+	new(args?: ObjectLookup<any>): Entity;
+	meta: Type;
 }
 
 export type EntityConstructorForType<T> =
@@ -442,7 +453,17 @@ export type EntityConstructorForType<T> =
 	T extends boolean ? never :
 	T extends Date ? never :
 	{
+		/**
+		 * Construct a new instance with no initial state specified
+		 */
+		new(): EntityOfType<T>;
+		/**
+		 * Construct an existing instance with persisted state
+		 */
 		new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;
+		/**
+		 * Construct a new instance with initial state
+		 */
 		new(args?: EntityArgsOfType<T>): EntityOfType<T>;
 		meta: TypeOfType<T>;
 	};

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -403,14 +403,14 @@ export type EntityDynamicPropertiesOfType<T> = {
 			) | null;
 };
 
-export interface TEntity<T> extends Entity {
+export interface EntityBasePropertiesOfType<T> extends Entity {
 	meta: ObjectMetaOfType<T>;
 	update(args: EntityArgsOfType<T>): Promise<void>;
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgsForType<T>>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgsForType<T>>;
 }
 
-export type EntityOfType<T> = TEntity<T> & EntityDynamicPropertiesOfType<T>;
+export type EntityOfType<T> = EntityBasePropertiesOfType<T> & EntityDynamicPropertiesOfType<T>;
 
 export type EntityConstructorForType<T> = {
     new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -436,11 +436,16 @@ export interface EntityConstructor {
 	new(properties?: ObjectLookup<any>): Entity; // Construct new instance with state
 }
 
-export type EntityConstructorForType<T> = {
-    new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;
-    new(args?: EntityArgsOfType<T>): EntityOfType<T>;
-	meta: TypeOfType<T>;
-};
+export type EntityConstructorForType<T> =
+	T extends string ? never :
+	T extends number ? never :
+	T extends boolean ? never :
+	T extends Date ? never :
+	{
+		new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;
+		new(args?: EntityArgsOfType<T>): EntityOfType<T>;
+		meta: TypeOfType<T>;
+	};
 
 export interface EntityRegisteredEventArgs {
 	entity: Entity;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -403,14 +403,14 @@ export type EntityDynamicPropertiesOfType<T> = {
 			) | null;
 };
 
-export interface EntityBasePropertiesOfType<T> extends Entity {
+export interface EntityBasePropertiesOfType<T> {
 	meta: ObjectMetaOfType<T>;
 	update(args: EntityArgsOfType<T>): Promise<void>;
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgsForType<T>>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgsForType<T>>;
 }
 
-export type EntityOfType<T> = EntityBasePropertiesOfType<T> & EntityDynamicPropertiesOfType<T>;
+export type EntityOfType<T> = Entity & EntityBasePropertiesOfType<T> & EntityDynamicPropertiesOfType<T>;
 
 export type EntityArgsOfType<T> = Partial<{
     -readonly [P in keyof T]:

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -405,6 +405,7 @@ export type EntityDynamicPropertiesOfType<T> = {
 
 export interface EntityBasePropertiesOfType<T> {
 	meta: ObjectMetaOfType<T>;
+	update(property: string, value?: any): Promise<void>;
 	update(args: EntityArgsOfType<T>): Promise<void>;
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgsForType<T>>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgsForType<T>>;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -412,12 +412,6 @@ export interface EntityBasePropertiesOfType<T> extends Entity {
 
 export type EntityOfType<T> = EntityBasePropertiesOfType<T> & EntityDynamicPropertiesOfType<T>;
 
-export type EntityConstructorForType<T> = {
-    new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;
-    new(args?: EntityArgsOfType<T>): EntityOfType<T>;
-	meta: TypeOfType<T>;
-};
-
 export type EntityArgsOfType<T> = Partial<{
     -readonly [P in keyof T]:
 		T[P] extends (infer TItem)[]
@@ -441,6 +435,12 @@ export interface EntityConstructor {
 	new(): Entity;
 	new(properties?: ObjectLookup<any>): Entity; // Construct new instance with state
 }
+
+export type EntityConstructorForType<T> = {
+    new(id: string, args?: EntityArgsOfType<T>): EntityOfType<T>;
+    new(args?: EntityArgsOfType<T>): EntityOfType<T>;
+	meta: TypeOfType<T>;
+};
 
 export interface EntityRegisteredEventArgs {
 	entity: Entity;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -1,6 +1,6 @@
 import { Event, EventObject, EventSubscriber } from "./events";
 import { Format } from "./format";
-import { Type, EntityType, isEntityType, getIdFromState, TypeOfType } from "./type";
+import { Type, ReferenceType, isEntityType, getIdFromState, TypeOfType } from "./type";
 import { InitializationContext } from "./initilization-context";
 import { ObjectMeta } from "./object-meta";
 import { Property, Property$init, Property$pendingInit, Property$setter } from "./property";
@@ -330,7 +330,7 @@ export class Entity {
 		// Get the entity format to use
 		let formatter: Format<Entity> = null;
 		if (format) {
-			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as EntityType, format, formatEval);
+			formatter = this.meta.type.model.getFormat<Entity>(this.constructor as ReferenceType, format, formatEval);
 		}
 		else {
 			formatter = this.meta.type.format;

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -475,28 +475,28 @@ export interface EntityRegisteredEventArgs {
 	entity: Entity;
 }
 
-export interface EntityRegisteredEventArgsForType<EntityType> {
-	entity: EntityOfType<EntityType>;
+export interface EntityRegisteredEventArgsForType<T> {
+	entity: EntityOfType<T>;
 }
 
 export interface EntityInitNewEventArgs {
 	entity: Entity;
 }
 
-export interface EntityInitNewEventArgsForType<EntityType> {
-	entity: EntityOfType<EntityType>;
+export interface EntityInitNewEventArgsForType<T> {
+	entity: EntityOfType<T>;
 }
 
 export interface EntityInitExistingEventArgs {
 	entity: Entity;
 }
 
-export interface EntityInitExistingEventArgsForType<EntityType> {
-	entity: EntityOfType<EntityType>;
+export interface EntityInitExistingEventArgsForType<T> {
+	entity: EntityOfType<T>;
 }
 
-export interface EntityAccessEventHandler<EntityType> {
-	(this: Property, args: EventObject & EntityAccessEventArgsForType<EntityType>): void;
+export interface EntityAccessEventHandler<T> {
+	(this: Property, args: EventObject & EntityAccessEventArgsForType<T>): void;
 }
 
 export interface EntityAccessEventArgs {
@@ -504,12 +504,12 @@ export interface EntityAccessEventArgs {
 	property: Property;
 }
 
-export interface EntityAccessEventArgsForType<EntityType> extends EntityAccessEventArgs {
-	entity: EntityOfType<EntityType>;
+export interface EntityAccessEventArgsForType<T> extends EntityAccessEventArgs {
+	entity: EntityOfType<T>;
 }
 
-export interface EntityChangeEventHandler<EntityType> {
-	(this: Property, args: EventObject & EntityChangeEventArgsForType<EntityType>): void;
+export interface EntityChangeEventHandler<T> {
+	(this: Property, args: EventObject & EntityChangeEventArgsForType<T>): void;
 }
 
 export interface EntityChangeEventArgs {
@@ -519,10 +519,10 @@ export interface EntityChangeEventArgs {
 	newValue: any;
 }
 
-export interface EntityChangeEventArgsForType<EntityType> extends EntityChangeEventArgs {
-	entity: EntityOfType<EntityType>;
+export interface EntityChangeEventArgsForType<T> extends EntityChangeEventArgs {
+	entity: EntityOfType<T>;
 }
 
-export function isEntity<EntityType>(obj): obj is EntityOfType<EntityType> {
+export function isEntity<T>(obj): obj is EntityOfType<T> {
 	return obj && obj.meta && obj.meta.type && obj.meta.type.jstype && isEntityType(obj.meta.type.jstype);
 }

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -301,7 +301,8 @@ describe("Entity", () => {
 
 			const movie = new Types.Movie(Alien);
 
-			const updateTask = movie.update({ Title: "Alien 2", Budget: "BUDGET_1" });
+			// NOTE: as Entity is necessary to avoid TS complaining about "Budget"
+			const updateTask = (movie as Entity).update({ Title: "Alien 2", Budget: "BUDGET_1" });
 
 			expect(movie.Title).toBe("Alien 2");
 			expect(movie.Budget).toBeNull();
@@ -783,7 +784,9 @@ describe("Entity", () => {
 					return Promise.resolve({ City: "Orlando", State: "Florida" });
 			});
 			const movie = new Types.Movie(Alien);
-			await movie.Director!.update({
+
+			// NOTE: as Entity is necessary to avoid TS complaining about "Address"
+			await (movie.Director as Entity).update({
 				Id: "1",
 				Address: "test_async_address"
 			});

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new */
 import { Model, ModelNamespace, ModelOfType } from "./model";
-import { Entity, EntityArgsOfType, EntityOfType, TEntityConstructor, isEntity } from "./entity";
+import { Entity, EntityArgsOfType, EntityOfType, EntityConstructorForType, isEntity } from "./entity";
 import "./resource-en";
 import { CultureInfo } from "./globalization";
 import { ArrayChangeType, updateArray } from "./observable-array";
@@ -531,7 +531,7 @@ describe("Entity", () => {
 				Test: Test;
 			};
 
-			let defaultTypes: { [T in keyof defaultNamespace]: TEntityConstructor<defaultNamespace[T]> } = {} as any;
+			let defaultTypes: { [T in keyof defaultNamespace]: EntityConstructorForType<defaultNamespace[T]> } = {} as any;
 
 			type Test = {
 				A: string;

--- a/src/entity.unit.ts
+++ b/src/entity.unit.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-new */
-import { Model, ModelNamespace, ModelOfType } from "./model";
+import { Model, ModelNamespace, ModelOfType, createModel } from "./model";
 import { Entity, EntityArgsOfType, EntityOfType, EntityConstructorForType, isEntity } from "./entity";
 import "./resource-en";
 import { CultureInfo } from "./globalization";
@@ -60,7 +60,7 @@ type Person = {
 
 function resetModel(ns?: any) {
 	CultureInfo.setup();
-	return Model.create<Namespace>({
+	return createModel<Namespace>({
 		$namespace: ns,
 		$locale: "en",
 		$culture: CultureInfo.CurrentCulture as any,
@@ -642,7 +642,7 @@ describe("Entity", () => {
 		let PersonWithSkillsTypes: ModelNamespace<PersonWithSkillsNamespace>;
 		beforeEach(async () => {
 			PersonWithSkillsTypes = {} as any;
-			await Model.create<PersonWithSkillsNamespace>({
+			await createModel<PersonWithSkillsNamespace>({
 				$namespace: PersonWithSkillsTypes,
 				Skill: {
 					Name: String,

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -179,8 +179,6 @@ describe("EventScope", () => {
 					type: Boolean,
 					get: {
 						dependsOn: "{FullName,FirstName,LastName}",
-						// Doesn't appear to be supported syntax
-						// defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
 						function(this: any) {
 							return this.FullName === `${this.FirstName.substring(0, 1)}. ${this.LastName}` ? true : this.FullName === this.toString("[FirstName] [LastName]") ? false : null;
 						}
@@ -190,8 +188,6 @@ describe("EventScope", () => {
 					type: "String",
 					get: {
 						dependsOn: "{AbbreviateName,FirstName,LastName}",
-						// Doesn't appear to be supported syntax
-						// defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
 						function(this: any) {
 							// The "Abbreviated" code path will throw an error if FirstName doesn't have a value
 							return this.AbbreviateName ? `${this.FirstName.substring(0, 1)}. ${this.LastName}` : this.toString("[FirstName] [LastName]");

--- a/src/event-scope.unit.ts
+++ b/src/event-scope.unit.ts
@@ -124,7 +124,7 @@ describe("EventScope", () => {
 			}
 		});
 
-		let eventScopeError: Error = null;
+		let eventScopeError: Error | null = null;
 		model.eventScope.onError.subscribe(e => { eventScopeError = e.error; e.preventDefault(); });
 
 		const context = new model.$namespace.Context();
@@ -136,12 +136,12 @@ describe("EventScope", () => {
 		expect(context.MatchedUser).not.toBeNull();
 		expect(context.MatchedUser.FullName).toBe("Dave Smith");
 		context.MatchedUser.FirstName = "Bob";
-		const maxNesting = model.eventScope.settings.maxExitingTransferCount - 1;
-		const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
+		// const maxNesting = model.eventScope.settings.maxExitingTransferCount - 1;
+		// const expectedCalculationCount = Math.floor(maxNesting / 4); // Each cycle appears to create 4 scopes, so it can calculate no more than maxNesting/4 times
 		expect(context.SearchText).toBe("abc123");
 		expect(model.eventScope.current).toBeNull();
 		expect(eventScopeError).not.toBeNull();
-		expect(eventScopeError.message).toBe("Exceeded max scope event transfer.");
+		expect(eventScopeError!.message).toBe("Exceeded max scope event transfer.");
 	});
 	it("aborts when the maximum scope depth is reached", async () => {
 		const model = new Model({
@@ -160,7 +160,8 @@ describe("EventScope", () => {
 					type: Boolean,
 					get: {
 						dependsOn: "{FullName,FirstName,LastName}",
-						defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
+						// Doesn't appear to be supported syntax
+						// defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
 						function(this: any) {
 							return this.FullName === `${this.FirstName.substring(0, 1)}. ${this.LastName}` ? true : this.FullName === this.toString("[FirstName] [LastName]") ? false : null;
 						}
@@ -170,7 +171,8 @@ describe("EventScope", () => {
 					type: "String",
 					get: {
 						dependsOn: "{AbbreviateName,FirstName,LastName}",
-						defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
+						// Doesn't appear to be supported syntax
+						// defaultIfError: undefined, // This is necessary to make sure the rule will fail if it throws an error
 						function(this: any) {
 							// The "Abbreviated" code path will throw an error if FirstName doesn't have a value
 							return this.AbbreviateName ? `${this.FirstName.substring(0, 1)}. ${this.LastName}` : this.toString("[FirstName] [LastName]");
@@ -185,7 +187,7 @@ describe("EventScope", () => {
 			maxEventScopeDepth: 100
 		});
 
-		let eventScopeError: Error = null;
+		let eventScopeError: Error | null = null;
 		model.eventScope.onError.subscribe(e => { eventScopeError = e.error; e.preventDefault(); });
 
 		const user1 = new model.$namespace.User({ FirstName: "Dave", LastName: "Smith" });
@@ -194,6 +196,6 @@ describe("EventScope", () => {
 		expect(user1.meta.conditions.length).toBe(0);
 		expect(user1.AbbreviateName).toBe(true);
 		expect(eventScopeError).not.toBeNull();
-		expect(eventScopeError.message).toBe("Exceeded max scope depth.");
+		expect(eventScopeError!.message).toBe("Exceeded max scope depth.");
 	});
 });

--- a/src/format.ts
+++ b/src/format.ts
@@ -82,8 +82,8 @@ export abstract class Format<T> {
 		return new CustomFormat<T>(model, options);
 	}
 
-	static fromTemplate<TEntity extends Entity>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<TEntity> {
-		return new ModelFormat<TEntity>(type, template, formatEval);
+	static fromTemplate<EntityType extends Entity>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityType> {
+		return new ModelFormat<EntityType>(type, template, formatEval);
 	}
 
 	static hasTokens(template: string): boolean {
@@ -93,7 +93,7 @@ export abstract class Format<T> {
 
 export interface FormatConstructor {
 	create<T>(options: CustomFormatOptions<T>): Format<T>;
-	fromTemplate<TEntity extends Entity>(type: Type, template: string, formatEval?: unknown): Format<TEntity>;
+	fromTemplate<EntityType extends Entity>(type: Type, template: string, formatEval?: unknown): Format<EntityType>;
 }
 
 export interface FormatOptions {

--- a/src/format.ts
+++ b/src/format.ts
@@ -82,8 +82,8 @@ export abstract class Format<T> {
 		return new CustomFormat<T>(model, options);
 	}
 
-	static fromTemplate<EntityType>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityOfType<EntityType>> {
-		return new ModelFormat<EntityOfType<EntityType>>(type, template, formatEval);
+	static fromTemplate<TEntity>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityOfType<TEntity>> {
+		return new ModelFormat<EntityOfType<TEntity>>(type, template, formatEval);
 	}
 
 	static hasTokens(template: string): boolean {
@@ -93,7 +93,7 @@ export abstract class Format<T> {
 
 export interface FormatConstructor {
 	create<T>(options: CustomFormatOptions<T>): Format<T>;
-	fromTemplate<EntityType>(type: Type, template: string, formatEval?: unknown): Format<EntityOfType<EntityType>>;
+	fromTemplate<TEntity>(type: Type, template: string, formatEval?: unknown): Format<EntityOfType<TEntity>>;
 }
 
 export interface FormatOptions {

--- a/src/format.ts
+++ b/src/format.ts
@@ -82,7 +82,6 @@ export abstract class Format<T> {
 		return new CustomFormat<T>(model, options);
 	}
 
-	// TODO: Infer from type? (Doesn't provide any value in this context)
 	static fromTemplate<EntityType>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityOfType<EntityType>> {
 		return new ModelFormat<EntityOfType<EntityType>>(type, template, formatEval);
 	}

--- a/src/format.ts
+++ b/src/format.ts
@@ -82,6 +82,7 @@ export abstract class Format<T> {
 		return new CustomFormat<T>(model, options);
 	}
 
+	// TODO: Infer from type? (Doesn't provide any value in this context)
 	static fromTemplate<EntityType extends Entity>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityType> {
 		return new ModelFormat<EntityType>(type, template, formatEval);
 	}

--- a/src/format.ts
+++ b/src/format.ts
@@ -2,7 +2,7 @@ import { FormatError } from "./format-error";
 import { Property } from "./property";
 import { PropertyChain } from "./property-chain";
 import { Type } from "./type";
-import { Entity } from "./entity";
+import { Entity, EntityOfType } from "./entity";
 import { evalPath, getConstructorName } from "./helpers";
 import { Model } from "./model";
 import { expandDateFormat, formatDate, parseDate, formatNumber, parseNumber, getNumberStyle } from "./globalization";
@@ -83,8 +83,8 @@ export abstract class Format<T> {
 	}
 
 	// TODO: Infer from type? (Doesn't provide any value in this context)
-	static fromTemplate<EntityType extends Entity>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityType> {
-		return new ModelFormat<EntityType>(type, template, formatEval);
+	static fromTemplate<EntityType>(type: Type, template: string, formatEval?: (tokenValue: string) => string): Format<EntityOfType<EntityType>> {
+		return new ModelFormat<EntityOfType<EntityType>>(type, template, formatEval);
 	}
 
 	static hasTokens(template: string): boolean {
@@ -94,7 +94,7 @@ export abstract class Format<T> {
 
 export interface FormatConstructor {
 	create<T>(options: CustomFormatOptions<T>): Format<T>;
-	fromTemplate<EntityType extends Entity>(type: Type, template: string, formatEval?: unknown): Format<EntityType>;
+	fromTemplate<EntityType>(type: Type, template: string, formatEval?: unknown): Format<EntityOfType<EntityType>>;
 }
 
 export interface FormatOptions {

--- a/src/list-length-rule.unit.ts
+++ b/src/list-length-rule.unit.ts
@@ -1,8 +1,9 @@
-import { Model } from "./model";
+import { TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 import "./resource-en";
 
-function createModel(options) {
+function createModel(options: ModelOptions) {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -12,25 +13,31 @@ function createModel(options) {
 }
 
 describe("ListLengthRule", () => {
+	type Namespace = {
+		Test: Test;
+	};
+
+	type Test = {
+		Array: string[];
+	};
+
 	test("Between", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Array: {
 					length: {
 						min: 1,
 						max: 2
 					},
-					type: "Test2[]"
-				}
-			},
-			Test2: {
-				Text: {
-					type: String
+					type: "String[]"
 				}
 			}
-		}) as any;
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		});
+
+		const t = new Types.Test();
 		expect(t.meta.conditions).toHaveLength(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Please specify between 1 and 2 Array.");
 
@@ -45,24 +52,21 @@ describe("ListLengthRule", () => {
 	});
 
 	test("Min", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Array: {
 					length: {
 						min: 1
 					},
-					type: "Test2[]"
+					type: "String[]"
 				}
-			},
-			Test2: {
-				Text: {
-					type: String
-				}
-
 			}
-		}) as any;
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		});
+
+		const t = new Types.Test();
 		expect(t.meta.conditions).toHaveLength(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Please specify at least 1 Array.");
 
@@ -71,24 +75,21 @@ describe("ListLengthRule", () => {
 	});
 
 	test("Max", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Array: {
 					length: {
 						max: 1
 					},
-					type: "Test2[]"
+					type: "String[]"
 				}
-			},
-			Test2: {
-				Text: {
-					type: String
-				}
-
 			}
-		}) as any;
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		});
+
+		const t = new Types.Test();
 		expect(t.meta.conditions).toHaveLength(0);
 
 		t.Array.push("1");

--- a/src/list-length-rule.unit.ts
+++ b/src/list-length-rule.unit.ts
@@ -1,31 +1,14 @@
-import { TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { createModel } from "./model";
 
 import "./resource-en";
 
-function createModel(options: ModelOptions) {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("ListLengthRule", () => {
-	type Namespace = {
-		Test: Test;
-	};
-
-	type Test = {
-		Array: string[];
-	};
-
 	test("Between", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await createModel<{
+			Test: {
+				Array: string[]
+			}
+		}>({
 			Test: {
 				Array: {
 					length: {
@@ -36,8 +19,7 @@ describe("ListLengthRule", () => {
 				}
 			}
 		});
-
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions).toHaveLength(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Please specify between 1 and 2 Array.");
 
@@ -52,10 +34,11 @@ describe("ListLengthRule", () => {
 	});
 
 	test("Min", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await createModel<{
+			Test: {
+				Array: string[]
+			}
+		}>({
 			Test: {
 				Array: {
 					length: {
@@ -65,8 +48,7 @@ describe("ListLengthRule", () => {
 				}
 			}
 		});
-
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions).toHaveLength(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Please specify at least 1 Array.");
 
@@ -75,10 +57,11 @@ describe("ListLengthRule", () => {
 	});
 
 	test("Max", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await createModel<{
+			Test: {
+				Array: string[]
+			}
+		}>({
 			Test: {
 				Array: {
 					length: {
@@ -88,8 +71,7 @@ describe("ListLengthRule", () => {
 				}
 			}
 		});
-
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions).toHaveLength(0);
 
 		t.Array.push("1");

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,7 @@
 import { Event, EventSubscriber } from "./events";
 import { replaceTokens, ObjectLookup } from "./helpers";
 import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs } from "./entity";
-import { Type, PropertyType, isEntityType, ValueType, TypeOptions, TypeExtensionOptions } from "./type";
+import { Type, PropertyType, isEntityType, ValueType, TypeOptions } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
 import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource, resourceExists } from "./resource";
@@ -31,7 +31,7 @@ export class Model {
 
 	readonly serializer = new EntitySerializer();
 
-	constructor(options?: ModelOptions & ModelNamespaceOption & ModelLocalizationOptions, config?: ModelConfiguration) {
+	constructor(options?: ModelOptions, config?: ModelConfiguration) {
 		this.types = {};
 		this.settings = new ModelSettings(config);
 		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs>();
@@ -158,7 +158,7 @@ export class Model {
 	 * Extends the model with the specified type information.
 	 * @param options The set of model types to add and/or extend.
 	 */
-	extend(options: ModelOptions & ModelNamespaceOption & ModelLocalizationOptions): void {
+	extend(options: ModelOptions): void {
 		// Use prepare() to defer property path resolution while the model is being extended
 		this.prepare(() => {
 			// Namespace
@@ -249,7 +249,7 @@ export class Model {
 					}
 				}
 
-				let typeOptions = options[typeName] as TypeOptions & TypeExtensionOptions<Entity>;
+				let typeOptions = options[typeName] as TypeOptions<Entity>;
 				let type = this.types[typeName];
 
 				typesToInitialize.push(typeName);
@@ -272,7 +272,7 @@ export class Model {
 
 			// Extend Types
 			for (let typeName of typesToInitialize) {
-				let typeOptions = options[typeName] as TypeOptions & TypeExtensionOptions<Entity>;
+				let typeOptions = options[typeName] as TypeOptions<Entity>;
 				this.types[typeName].extend(typeOptions);
 			}
 		});
@@ -374,11 +374,11 @@ export interface ModelConstructor {
 	new(createOwnProperties?: boolean): Model;
 }
 
-export type ModelOptions = {
+export type ModelTypeOptions = {
 	/**
 	 * Standard type options ($extends and $format), properties, and methods/rules
 	 */
-	[name: string]: (TypeOptions & TypeExtensionOptions<Entity>) | string;
+	[name: string]: (TypeOptions<Entity>) | string;
 }
 
 export type ModelLocalizationOptions = {
@@ -404,6 +404,8 @@ export type ModelNamespaceOption = {
 	 */
 	$namespace?: object;
 }
+
+export type ModelOptions = ModelTypeOptions & ModelNamespaceOption & ModelLocalizationOptions;
 
 export type ModelConfiguration = {
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -359,7 +359,7 @@ export class Model {
 
 		// Otherwise, create and cache the format
 		if (isEntityType(type)) {
-			return (formats[format] = Format.fromTemplate(type.meta, format, formatEval)) as Format<T>;
+			return (formats[format] = Format.fromTemplate<unknown>(type.meta, format, formatEval)) as unknown as Format<T>;
 		}
 		else {
 			// otherwise, call the format provider to create a new format

--- a/src/model.ts
+++ b/src/model.ts
@@ -20,9 +20,9 @@ export class Model {
 	readonly $resources: LocalizedResourcesMap;
 	readonly $culture: CultureInfo;
 
-	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs>;
-	readonly afterPropertySet: EventSubscriber<Entity, EntityChangeEventArgs>;
-	readonly listChanged: EventSubscriber<Entity, EntityChangeEventArgs>;
+	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs<Entity>>;
+	readonly afterPropertySet: EventSubscriber<Entity, EntityChangeEventArgs<Entity>>;
+	readonly listChanged: EventSubscriber<Entity, EntityChangeEventArgs<Entity>>;
 	readonly eventScope: EventScope;
 
 	private _readyCallbacks: (() => void)[];
@@ -34,9 +34,9 @@ export class Model {
 	constructor(options?: ModelOptions, config?: ModelConfiguration) {
 		this.types = {};
 		this.settings = new ModelSettings(config);
-		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs>();
-		this.afterPropertySet = new Event<Entity, EntityChangeEventArgs>();
-		this.listChanged = new Event<Entity, EntityChangeEventArgs>();
+		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs<Entity>>();
+		this.afterPropertySet = new Event<Entity, EntityChangeEventArgs<Entity>>();
+		this.listChanged = new Event<Entity, EntityChangeEventArgs<Entity>>();
 		this.eventScope = EventScope.create(this.settings.eventScopeSettings);
 
 		Object.defineProperty(this, "_formats", { enumerable: false, configurable: false, writable: true, value: {} });
@@ -378,7 +378,7 @@ export type ModelTypeOptions = {
 	/**
 	 * Standard type options ($extends and $format), properties, and methods/rules
 	 */
-	[name: string]: (TypeOptions<Entity>) | string;
+	[name: string]: (TypeOptions<any>) | string;
 }
 
 export type ModelLocalizationOptions = {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,7 +1,7 @@
 import { Event, EventSubscriber } from "./events";
 import { replaceTokens, ObjectLookup } from "./helpers";
 import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs, EntityConstructorForType } from "./entity";
-import { Type, PropertyType, isEntityType, ValueConstructor, TypeOptions, TypeOfType } from "./type";
+import { Type, PropertyType, isEntityType, ValueConstructor, TypeOptionsForType, TypeOfType } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
 import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource, resourceExists } from "./resource";
@@ -249,7 +249,7 @@ export class Model {
 					}
 				}
 
-				let typeOptions = options[typeName] as TypeOptions<unknown>;
+				let typeOptions = options[typeName] as TypeOptionsForType<unknown>;
 				let type = this.types[typeName];
 
 				typesToInitialize.push(typeName);
@@ -272,7 +272,7 @@ export class Model {
 
 			// Extend Types
 			for (let typeName of typesToInitialize) {
-				let typeOptions = options[typeName] as TypeOptions<unknown>;
+				let typeOptions = options[typeName] as TypeOptionsForType<unknown>;
 				this.types[typeName].extend(typeOptions);
 			}
 		});
@@ -397,7 +397,7 @@ export type ModelTypeOptions<TTypes> = {
 	/**
 	 * Standard type options ($extends and $format), properties, and methods/rules
 	 */
-	[T in keyof TTypes]: (TypeOptions<TTypes[T]>) | string;
+	[T in keyof TTypes]: (TypeOptionsForType<TTypes[T]>) | string;
 }
 
 export type ModelLocalizationOptions = {

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,14 +1,14 @@
 import { Event, EventSubscriber } from "./events";
 import { replaceTokens, ObjectLookup } from "./helpers";
 import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs, EntityConstructorForType } from "./entity";
-import { Type, PropertyType, isEntityType, ValueType, TypeOptions, TypeOfType } from "./type";
+import { Type, PropertyType, isEntityType, ValueConstructor, TypeOptions, TypeOfType } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
 import { LocalizedResourcesMap, setDefaultLocale, defineResources, getResource, resourceExists } from "./resource";
 import { CultureInfo, formatNumber, parseNumber, formatDate, parseDate, expandDateFormat, getNumberStyle } from "./globalization";
 import { EventScope, EventScopeSettings, EVENT_SCOPE_DEFAULT_SETTINGS } from "./event-scope";
 
-const valueTypes: { [name: string]: ValueType } = { string: String, number: Number, date: Date, boolean: Boolean };
+const valueTypes: { [name: string]: ValueConstructor } = { string: String, number: Number, date: Date, boolean: Boolean };
 
 export class Model {
 	readonly types: { [name: string]: Type };
@@ -27,7 +27,7 @@ export class Model {
 
 	private _readyCallbacks: (() => void)[];
 	private _readyProcessing = false;
-	private readonly _formats: { [name: string]: { [name: string]: Format<ValueType> } };
+	private readonly _formats: { [name: string]: { [name: string]: Format<ValueConstructor> } };
 
 	readonly serializer = new EntitySerializer();
 

--- a/src/model.ts
+++ b/src/model.ts
@@ -158,7 +158,7 @@ export class Model {
 	 * Extends the model with the specified type information.
 	 * @param options The set of model types to add and/or extend.
 	 */
-	extend(options: ModelOptions<any>): void {
+	extend(options: ModelOptions<unknown>): void {
 		// Use prepare() to defer property path resolution while the model is being extended
 		this.prepare(() => {
 			// Namespace
@@ -425,7 +425,7 @@ export type ModelNamespaceOption<TTypes> = {
 	/**
 	 * The object to use as the namespace for model types
 	 */
-	$namespace?: ModelNamespace<TTypes>;
+	$namespace?: Partial<ModelNamespace<TTypes>>;
 }
 
 export type ModelOptions<TTypes> = ModelTypeOptions<TTypes> & ModelNamespaceOption<TTypes> & ModelLocalizationOptions;

--- a/src/model.ts
+++ b/src/model.ts
@@ -1,6 +1,6 @@
 import { Event, EventSubscriber } from "./events";
 import { replaceTokens, ObjectLookup } from "./helpers";
-import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs, TEntityConstructor } from "./entity";
+import { EntityRegisteredEventArgs, Entity, EntityChangeEventArgs, EntityConstructorForType } from "./entity";
 import { Type, PropertyType, isEntityType, ValueType, TypeOptions, TypeOfType } from "./type";
 import { Format, createFormat } from "./format";
 import { EntitySerializer } from "./entity-serializer";
@@ -20,9 +20,9 @@ export class Model {
 	readonly $resources: LocalizedResourcesMap;
 	readonly $culture: CultureInfo;
 
-	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs<Entity>>;
-	readonly afterPropertySet: EventSubscriber<Entity, EntityChangeEventArgs<Entity>>;
-	readonly listChanged: EventSubscriber<Entity, EntityChangeEventArgs<Entity>>;
+	readonly entityRegistered: EventSubscriber<Model, EntityRegisteredEventArgs>;
+	readonly afterPropertySet: EventSubscriber<Entity, EntityChangeEventArgs>;
+	readonly listChanged: EventSubscriber<Entity, EntityChangeEventArgs>;
 	readonly eventScope: EventScope;
 
 	private _readyCallbacks: (() => void)[];
@@ -34,9 +34,9 @@ export class Model {
 	constructor(options?: ModelOptions<any>, config?: ModelConfiguration) {
 		this.types = {};
 		this.settings = new ModelSettings(config);
-		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs<Entity>>();
-		this.afterPropertySet = new Event<Entity, EntityChangeEventArgs<Entity>>();
-		this.listChanged = new Event<Entity, EntityChangeEventArgs<Entity>>();
+		this.entityRegistered = new Event<Model, EntityRegisteredEventArgs>();
+		this.afterPropertySet = new Event<Entity, EntityChangeEventArgs>();
+		this.listChanged = new Event<Entity, EntityChangeEventArgs>();
 		this.eventScope = EventScope.create(this.settings.eventScopeSettings);
 
 		Object.defineProperty(this, "_formats", { enumerable: false, configurable: false, writable: true, value: {} });
@@ -359,7 +359,7 @@ export class Model {
 
 		// Otherwise, create and cache the format
 		if (isEntityType(type)) {
-			return (formats[format] = Format.fromTemplate(type.meta, format, formatEval));
+			return (formats[format] = Format.fromTemplate(type.meta, format, formatEval)) as Format<T>;
 		}
 		else {
 			// otherwise, call the format provider to create a new format
@@ -418,7 +418,7 @@ export type ModelLocalizationOptions = {
 }
 
 export type ModelNamespace<TTypes> = {
-	[T in keyof TTypes]: TEntityConstructor<TTypes[T]>;
+	[T in keyof TTypes]: EntityConstructorForType<TTypes[T]>;
 }
 
 export type ModelNamespaceOption<TTypes> = {

--- a/src/model.ts
+++ b/src/model.ts
@@ -260,7 +260,7 @@ export class Model {
 					}
 				}
 
-				let typeOptions = options[typeName] as TypeOptions<Entity>;
+				let typeOptions = options[typeName] as TypeOptions<unknown>;
 				let type = this.types[typeName];
 
 				typesToInitialize.push(typeName);
@@ -283,7 +283,7 @@ export class Model {
 
 			// Extend Types
 			for (let typeName of typesToInitialize) {
-				let typeOptions = options[typeName] as TypeOptions<Entity>;
+				let typeOptions = options[typeName] as TypeOptions<unknown>;
 				this.types[typeName].extend(typeOptions);
 			}
 		});

--- a/src/model.ts
+++ b/src/model.ts
@@ -46,17 +46,6 @@ export class Model {
 		}
 	}
 
-	static create<TTypes>(options?: ModelTypeOptions<TTypes> & Required<ModelNamespaceOption<TTypes>> & ModelLocalizationOptions, config?: ModelConfiguration): Promise<ModelOfType<TTypes> & ModelWithNamespace<TTypes>>;
-	static create<TTypes>(options?: ModelTypeOptions<TTypes> & ModelLocalizationOptions, config?: ModelConfiguration): Promise<ModelOfType<TTypes> & ModelNamespace<TTypes>>;
-	static create<TTypes>(options?: ModelOptions<TTypes>, config?: ModelConfiguration): Promise<ModelOfType<TTypes>> {
-		return new Promise((resolve) => {
-			const model = new Model(options, config);
-			model.ready(() => {
-				resolve(model as ModelOfType<TTypes>);
-			});
-		});
-	}
-
 	/**
 	 * Sets the default locale to use when a model's locale is not explicitly set
 	 * @param locale The default locale
@@ -379,6 +368,17 @@ export class Model {
 		}
 		return jstype;
 	}
+}
+
+export function createModel<TTypes>(options?: ModelTypeOptions<TTypes> & Required<ModelNamespaceOption<TTypes>> & ModelLocalizationOptions, config?: ModelConfiguration): Promise<ModelOfType<TTypes> & ModelWithNamespace<TTypes>>;
+export function createModel<TTypes>(options?: ModelTypeOptions<TTypes> & ModelLocalizationOptions, config?: ModelConfiguration): Promise<ModelOfType<TTypes> & ModelNamespace<TTypes>>;
+export function createModel<TTypes>(options?: ModelOptions<TTypes>, config?: ModelConfiguration): Promise<ModelOfType<TTypes>> {
+	return new Promise((resolve) => {
+		const model = new Model(options, config);
+		model.ready(() => {
+			resolve(model as ModelOfType<TTypes>);
+		});
+	});
 }
 
 export interface ModelOfType<TTypes> extends Model {

--- a/src/object-meta.ts
+++ b/src/object-meta.ts
@@ -1,5 +1,5 @@
-import { Type } from "./type";
-import { Entity } from "./entity";
+import { Type, TypeOfType } from "./type";
+import { Entity, EntityOfType } from "./entity";
 import { ConditionTarget } from "./condition-target";
 import { ConditionType, PermissionConditionType } from "./condition-type";
 import { ObservableArray } from "./observable-array";
@@ -84,4 +84,9 @@ export class ObjectMeta {
 
 		return true;
 	}
+}
+
+export interface ObjectMetaOfType<T> extends ObjectMeta {
+	readonly type: TypeOfType<T>;
+	readonly entity: EntityOfType<T>;
 }

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -1,4 +1,4 @@
-import { Type, EntityType } from "./type";
+import { Type, ReferenceType } from "./type";
 import { Property, PropertyBooleanFunction } from "./property";
 import { PropertyPath, PropertyAccessEventArgs, PropertyChangeEventArgs, PropertyChangeEventHandler, PropertyAccessEventHandler } from "./property-path";
 import { Event, EventSubscriber, EventPublisher } from "./events";
@@ -343,7 +343,7 @@ function getPropertyChainPathFromIndex(chain: PropertyChain, startIndex: number)
 			}
 		}
 		steps.push(p.name);
-		previousStepType = (p.propertyType as EntityType).meta;
+		previousStepType = (p.propertyType as ReferenceType).meta;
 	});
 
 	return steps.join(".");

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -13,7 +13,7 @@ import { Format } from "./format";
 export class PropertyChain implements PropertyPath {
 	readonly rootType: Type;
 	readonly properties: Property[];
-	readonly required: boolean | PropertyBooleanFunction<Entity>;
+	readonly required: boolean | PropertyBooleanFunction<unknown>;
 	readonly changed: EventSubscriber<Entity, PropertyChangeEventArgs>;
 	readonly accessed: EventSubscriber<Entity, PropertyAccessEventArgs>;
 

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -13,7 +13,7 @@ import { Format } from "./format";
 export class PropertyChain implements PropertyPath {
 	readonly rootType: Type;
 	readonly properties: Property[];
-	readonly required: boolean | PropertyBooleanFunction;
+	readonly required: boolean | PropertyBooleanFunction<Entity>;
 	readonly changed: EventSubscriber<Entity, PropertyChangeEventArgs>;
 	readonly accessed: EventSubscriber<Entity, PropertyAccessEventArgs>;
 

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -43,7 +43,7 @@ export class PropertyChain implements PropertyPath {
 			}
 
 			// Get the current type of the step
-			currentType = (property.propertyType as EntityConstructorForType<any>).meta;
+			currentType = (property.propertyType as EntityConstructorForType<unknown>).meta;
 			if (parsed[3]) {
 				currentType = rootType.model.types[parsed[3]];
 			}
@@ -343,7 +343,7 @@ function getPropertyChainPathFromIndex(chain: PropertyChain, startIndex: number)
 			}
 		}
 		steps.push(p.name);
-		previousStepType = (p.propertyType as EntityConstructorForType<any>).meta;
+		previousStepType = (p.propertyType as EntityConstructorForType<unknown>).meta;
 	});
 
 	return steps.join(".");

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -1,4 +1,4 @@
-import { Type, ReferenceType } from "./type";
+import { Type, EntityType } from "./type";
 import { Property, PropertyBooleanFunction } from "./property";
 import { PropertyPath, PropertyAccessEventArgs, PropertyChangeEventArgs, PropertyChangeEventHandler, PropertyAccessEventHandler } from "./property-path";
 import { Event, EventSubscriber, EventPublisher } from "./events";
@@ -343,7 +343,7 @@ function getPropertyChainPathFromIndex(chain: PropertyChain, startIndex: number)
 			}
 		}
 		steps.push(p.name);
-		previousStepType = (p.propertyType as ReferenceType).meta;
+		previousStepType = (p.propertyType as EntityType).meta;
 	});
 
 	return steps.join(".");

--- a/src/property-chain.ts
+++ b/src/property-chain.ts
@@ -1,4 +1,4 @@
-import { Type, EntityType } from "./type";
+import { Type } from "./type";
 import { Property, PropertyBooleanFunction } from "./property";
 import { PropertyPath, PropertyAccessEventArgs, PropertyChangeEventArgs, PropertyChangeEventHandler, PropertyAccessEventHandler } from "./property-path";
 import { Event, EventSubscriber, EventPublisher } from "./events";
@@ -43,7 +43,7 @@ export class PropertyChain implements PropertyPath {
 			}
 
 			// Get the current type of the step
-			currentType = (property.propertyType as EntityConstructorForType<Entity>).meta;
+			currentType = (property.propertyType as EntityConstructorForType<any>).meta;
 			if (parsed[3]) {
 				currentType = rootType.model.types[parsed[3]];
 			}
@@ -343,7 +343,7 @@ function getPropertyChainPathFromIndex(chain: PropertyChain, startIndex: number)
 			}
 		}
 		steps.push(p.name);
-		previousStepType = (p.propertyType as EntityType).meta;
+		previousStepType = (p.propertyType as EntityConstructorForType<any>).meta;
 	});
 
 	return steps.join(".");

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -1,28 +1,11 @@
 import { PropertyChain } from "./property-chain";
-import { Model, ModelOptions } from "./model";
-import { TEntityConstructor } from "./entity";
-
-function createModel(options: ModelOptions): Promise<Model> {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
+import { createModel } from "./model";
 
 describe("PropertyChain", () => {
 	it("Doesn't call PropertyChain.testConnection() when not needed", async () => {
 		// To simulate a scenario where calling testConnection would cause a significant performance impact
 		// we create a model that has some type (Person).This type has multiple properties (GroupName, GroupId, GroupCountry etc...)
 		// that references back to one shared object's (Group) properties
-
-		type Namespace = {
-			Person: Person;
-			Group: Group;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
 
 		type Person = {
 			Name: string;
@@ -40,8 +23,10 @@ describe("PropertyChain", () => {
 			Language: string;
 		};
 
-		await createModel({
-			$namespace: Types as any,
+		const { Person, Group } = await createModel<{
+			Person: Person;
+			Group: Group;
+		}>({
 			Person: {
 				Name: {
 					type: String,
@@ -54,28 +39,28 @@ describe("PropertyChain", () => {
 					type: String,
 					get: {
 					  dependsOn: "Group.Name",
-					  function(this: Person) { return this.Group.Name; }
+					  function() { return this.Group!.Name; }
 					}
 				},
 				GroupId: {
 					type: String,
 					get: {
 					  dependsOn: "Group.Id",
-					  function() { return this.Group.Id; }
+					  function() { return this.Group!.Id; }
 					}
 				},
 				GroupCountry: {
 					type: String,
 					get: {
 					  dependsOn: "Group.Country",
-					  function() { return this.Group.Country; }
+					  function() { return this.Group!.Country; }
 					}
 				},
 				GroupLanguage: {
 					type: String,
 					get: {
 					  dependsOn: "Group.Language",
-					  function() { return this.Group.Language; }
+					  function() { return this.Group!.Language; }
 					}
 				}
 			},
@@ -91,11 +76,11 @@ describe("PropertyChain", () => {
 		// The effect is more pronounced when there are a large number of objects in memory.
 		for (let i = 0; i < 1000; i++) {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const person = new Types.Person({ Name: "Dude Man" });
+			const person = new Person({ Name: "Dude Man" });
 		}
 
 		// Create new Group
-		const group = new Types.Group({
+		const group = new Group({
 			Name: "Test Group",
 			Id: "XDA-1V9-AM3",
 			Country: "US",
@@ -110,7 +95,7 @@ describe("PropertyChain", () => {
 		// on the Person's container object, which would unnecessarily loop over pooled entities to
 		// see if they are linked to the changed entity via a null property. This is where the slowdown comes into play.
 		// With the fix, we would prevent unnecessarily looping over said entities.
-		for (let p of Types.Person.meta.known())
+		for (let p of Person.meta.known())
 			p.Group = group;
 
 		//	Assure that testConnection() is not called (we are not unnecessarily looping) on initial assignment

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -1,9 +1,8 @@
 import { PropertyChain } from "./property-chain";
-import { Model } from "./model";
-import { TypeOfType } from "./type";
-import { EntityConstructorForType, EntityOfType, TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
+import { TEntityConstructor } from "./entity";
 
-function createModel(options): Promise<Model> {
+function createModel(options: ModelOptions): Promise<Model> {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -41,8 +40,8 @@ describe("PropertyChain", () => {
 			Language: string;
 		};
 
-		const model = await createModel({
-			$namespace: Types,
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				Name: {
 					type: String,
@@ -88,18 +87,15 @@ describe("PropertyChain", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person") as unknown as EntityConstructorForType<EntityOfType<Person>>;
-
 		// Create multiple Persons (will just sit in memory)
 		// The effect is more pronounced when there are a large number of objects in memory.
 		for (let i = 0; i < 1000; i++) {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			const person = new Person({ Name: "Dude Man" });
+			const person = new Types.Person({ Name: "Dude Man" });
 		}
 
 		// Create new Group
-		const Group = model.getJsType("Group") as unknown as EntityConstructorForType<EntityOfType<Group>>;
-		const group = new Group({
+		const group = new Types.Group({
 			Name: "Test Group",
 			Id: "XDA-1V9-AM3",
 			Country: "US",
@@ -114,7 +110,7 @@ describe("PropertyChain", () => {
 		// on the Person's container object, which would unnecessarily loop over pooled entities to
 		// see if they are linked to the changed entity via a null property. This is where the slowdown comes into play.
 		// With the fix, we would prevent unnecessarily looping over said entities.
-		for (let p of (Person.meta as TypeOfType<Person>).known())
+		for (let p of Types.Person.meta.known())
 			p.Group = group;
 
 		//	Assure that testConnection() is not called (we are not unnecessarily looping) on initial assignment

--- a/src/property-chain.unit.ts
+++ b/src/property-chain.unit.ts
@@ -54,7 +54,7 @@ describe("PropertyChain", () => {
 					type: String,
 					get: {
 					  dependsOn: "Group.Name",
-					  function() { return this.Group.Name; }
+					  function(this: Person) { return this.Group.Name; }
 					}
 				},
 				GroupId: {

--- a/src/property-path.ts
+++ b/src/property-path.ts
@@ -10,7 +10,7 @@ export interface PropertyPath {
 	readonly name: string;
 	readonly propertyType: PropertyType;
 	readonly isList: boolean;
-	readonly required: boolean | PropertyBooleanFunction<any> | PropertyBooleanFunctionAndOptions<any>;
+	readonly required: boolean | PropertyBooleanFunction<unknown> | PropertyBooleanFunctionAndOptions<unknown>;
 	readonly path: string;
 	readonly firstProperty: Property;
 	readonly lastProperty: Property;

--- a/src/property-path.ts
+++ b/src/property-path.ts
@@ -10,7 +10,7 @@ export interface PropertyPath {
 	readonly name: string;
 	readonly propertyType: PropertyType;
 	readonly isList: boolean;
-	readonly required: boolean | PropertyBooleanFunction<Entity> | PropertyBooleanFunctionAndOptions<Entity>;
+	readonly required: boolean | PropertyBooleanFunction<any> | PropertyBooleanFunctionAndOptions<any>;
 	readonly path: string;
 	readonly firstProperty: Property;
 	readonly lastProperty: Property;

--- a/src/property-path.ts
+++ b/src/property-path.ts
@@ -10,7 +10,7 @@ export interface PropertyPath {
 	readonly name: string;
 	readonly propertyType: PropertyType;
 	readonly isList: boolean;
-	readonly required: boolean | PropertyBooleanFunction | PropertyBooleanFunctionAndOptions;
+	readonly required: boolean | PropertyBooleanFunction<Entity> | PropertyBooleanFunctionAndOptions<Entity>;
 	readonly path: string;
 	readonly firstProperty: Property;
 	readonly lastProperty: Property;

--- a/src/property.ts
+++ b/src/property.ts
@@ -611,10 +611,10 @@ export class Property implements PropertyPath {
 }
 
 // TODO: update generic type args
-export interface PropertyOptions<EntityType, P> {
+export interface PropertyOptions<TEntity, TProperty> {
 
 	/** The name or Javascript type of the property */
-	type: string | PropertyTypeForType<P>;
+	type: string | PropertyTypeForType<TProperty>;
 
 	/**
 	*  The optional label for the property.
@@ -636,43 +636,43 @@ export interface PropertyOptions<EntityType, P> {
 	helptext?: string;
 
 	/** The optional format specifier for the property. */
-	format?: string | Format<P> | PropertyFormatOptions<EntityType>;
+	format?: string | Format<TProperty> | PropertyFormatOptions<TEntity>;
 
 	/** A non-null value if the property is constant */
 	constant?: any;
 
 	/** An optional function or dependency function object that calculates the value of this property. */
-	get?: PropertyValueFunction<EntityType, any> | PropertyValueFunctionAndOptions<EntityType, any>;
+	get?: PropertyValueFunction<TEntity, any> | PropertyValueFunctionAndOptions<TEntity, any>;
 
 	/** An optional function to call when this property is updated. */
-	set?: (this: EntityOfType<EntityType>, value: any) => void;
+	set?: (this: EntityOfType<TEntity>, value: any) => void;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
-	default?: PropertyValueFunction<EntityType, any> | PropertyValueFunctionAndOptions<EntityType, any> | Value | Value[] | null;
+	default?: PropertyValueFunction<TEntity, any> | PropertyValueFunctionAndOptions<TEntity, any> | Value | Value[] | null;
 
 	/** A function used to obtain the value with which to initialize this property.
 	 * The function is called only once, and is not reactive as a rule would be.
 	 * Does not overwrite a property value provided during construction of the containing entity.
 	 */
-	init?: PropertyValueFunction<EntityType, any>;
+	init?: PropertyValueFunction<TEntity, any>;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
-	allowedValues?: PropertyValueFunction<EntityType, any[]> | AllowedValuesFunctionAndOptions<EntityType, any[]> | Value[];
+	allowedValues?: PropertyValueFunction<TEntity, any[]> | AllowedValuesFunctionAndOptions<TEntity, any[]> | Value[];
 
 	/** True if the property is always required, or a dependency function object for conditionally required properties. */
-	required?: boolean | PropertyBooleanFunction<EntityType> | PropertyBooleanFunctionAndOptions<EntityType>;
+	required?: boolean | PropertyBooleanFunction<TEntity> | PropertyBooleanFunctionAndOptions<TEntity>;
 
 	/** An optional dependency function object that adds an error with the specified message when true. */
-	error?: PropertyErrorFunctionAndOptions<EntityType> | PropertyErrorFunctionAndOptions<EntityType>[];
+	error?: PropertyErrorFunctionAndOptions<TEntity> | PropertyErrorFunctionAndOptions<TEntity>[];
 
 	/** Optional contant or function-based min and max values. */
-	range?: PropertyRangeOptions<EntityType, any>;
+	range?: PropertyRangeOptions<TEntity, any>;
 
 	/** Optional contant or function-based min and max length. */
-	length?: PropertyLengthOptions<EntityType>;
+	length?: PropertyLengthOptions<TEntity>;
 }
 
-export interface PropertyFormatOptions<EntityType> {
+export interface PropertyFormatOptions<TEntity> {
 
 	/** The human readable description of the format, such as MM/DD/YYY */
 	description: string;
@@ -683,29 +683,29 @@ export interface PropertyFormatOptions<EntityType> {
 	/** An optional regular expression reformat string that will be used to correct the value if it matches */
 	reformat?: string;
 
-	message?: string | ((this: EntityOfType<EntityType>) => string | null | undefined);
+	message?: string | ((this: EntityOfType<TEntity>) => string | null | undefined);
 }
 
-export interface PropertyErrorFunctionAndOptions<EntityType> {
-	function: (this: EntityOfType<EntityType>) => string | null | undefined;
+export interface PropertyErrorFunctionAndOptions<TEntity> {
+	function: (this: EntityOfType<TEntity>) => string | null | undefined;
 	dependsOn: string;
 	resource?: string;
 	code?: string;
 	properties?: string[];
 }
 
-export type PropertyValueFunction<EntityType, T> = (this: EntityOfType<EntityType>) => T;
+export type PropertyValueFunction<TEntity, TResult> = (this: EntityOfType<TEntity>) => TResult;
 
-export interface PropertyValueFunctionAndOptions<EntityType, ResultType> {
-	function: (this: EntityOfType<EntityType>) => ResultType;
+export interface PropertyValueFunctionAndOptions<TEntity, TResult> {
+	function: (this: EntityOfType<TEntity>) => TResult;
 	dependsOn?: string;
 }
 
-export function isPropertyValueFunction<EntityType, T>(obj: any): obj is PropertyValueFunction<EntityType, T> {
+export function isPropertyValueFunction<TEntity, TResult>(obj: any): obj is PropertyValueFunction<TEntity, TResult> {
 	return typeof (obj) === "function";
 }
 
-export interface AllowedValuesFunctionAndOptions<EntityType, ResultType> extends PropertyValueFunctionAndOptions<EntityType, ResultType> {
+export interface AllowedValuesFunctionAndOptions<TEntity, TResult> extends PropertyValueFunctionAndOptions<TEntity, TResult> {
 	ignoreValidation?: boolean;
 	preventInvalidValues?: boolean;
 }
@@ -714,31 +714,31 @@ type LambdaFunction<ReturnType> = () => ReturnType;
 
 type BoundFunction<ThisType, ReturnType> = (this: ThisType) => ReturnType;
 
-export interface PropertyRangeOptions<EntityType, T> {
-	min?: T | LambdaFunction<T> | BoundFunction<EntityOfType<EntityType>, T>;
-	max?: T | LambdaFunction<T> | BoundFunction<EntityOfType<EntityType>, T>;
+export interface PropertyRangeOptions<TEntity, TValue> {
+	min?: TValue | LambdaFunction<TValue> | BoundFunction<EntityOfType<TEntity>, TValue>;
+	max?: TValue | LambdaFunction<TValue> | BoundFunction<EntityOfType<TEntity>, TValue>;
 	dependsOn?: string;
 }
 
-export interface PropertyLengthOptions<EntityType> {
-	min?: number | LambdaFunction<number> | BoundFunction<EntityOfType<EntityType>, number>;
-	max?: number | LambdaFunction<number> | BoundFunction<EntityOfType<EntityType>, number>;
+export interface PropertyLengthOptions<TEntity> {
+	min?: number | LambdaFunction<number> | BoundFunction<EntityOfType<TEntity>, number>;
+	max?: number | LambdaFunction<number> | BoundFunction<EntityOfType<TEntity>, number>;
 	dependsOn?: string;
 }
 
-export type PropertyBooleanFunction<EntityType> = (this: EntityOfType<EntityType>) => boolean;
+export type PropertyBooleanFunction<TEntity> = (this: EntityOfType<TEntity>) => boolean;
 
-export interface PropertyBooleanFunctionAndOptions<EntityType> {
-	function?: (this: EntityOfType<EntityType>) => boolean;
+export interface PropertyBooleanFunctionAndOptions<TEntity> {
+	function?: (this: EntityOfType<TEntity>) => boolean;
 	dependsOn?: string;
-	message?: string | ((this: EntityOfType<EntityType>) => string | null | undefined);
+	message?: string | ((this: EntityOfType<TEntity>) => string | null | undefined);
 }
 
-export function isPropertyBooleanFunctionAndOptions<EntityType>(obj: any): obj is PropertyBooleanFunctionAndOptions<EntityType> {
+export function isPropertyBooleanFunctionAndOptions<TEntity>(obj: any): obj is PropertyBooleanFunctionAndOptions<TEntity> {
 	return typeof (obj) === "object";
 }
 
-export function isPropertyBooleanFunction<EntityType>(obj: any): obj is PropertyBooleanFunction<EntityType> {
+export function isPropertyBooleanFunction<TEntity>(obj: any): obj is PropertyBooleanFunction<TEntity> {
 	return typeof (obj) === "function";
 }
 
@@ -746,8 +746,8 @@ export function isPropertyOptions<TOptions>(obj: any, check: (options: any) => b
 	return isType<TOptions>(obj, d => getTypeName(d) === "object" && (!check || check(d)));
 }
 
-export interface PropertyConstructor<E, P> {
-	new(containingType: TypeOfType<E>, name: string, jstype: PropertyType, isList: boolean, options?: PropertyOptions<E, P>): Property;
+export interface PropertyConstructor<TEntity, P> {
+	new(containingType: TypeOfType<TEntity>, name: string, jstype: PropertyType, isList: boolean, options?: PropertyOptions<TEntity, P>): Property;
 }
 
 export type PropertyGetMethod = (property: Property, entity: Entity, additionalArgs: any) => any;

--- a/src/property.ts
+++ b/src/property.ts
@@ -26,13 +26,13 @@ export class Property implements PropertyPath {
 	readonly isList: boolean;
 
 	constant: any;
-	initializer: (this: Entity) => any;
+	initializer: (this: EntityOfType<unknown>) => any;
 	label: string;
 	labelSource: PropertyPath;
 	helptext: string;
 	isCalculated: boolean;
 	format: Format<any>;
-	required: boolean | PropertyBooleanFunction<Entity> | PropertyBooleanFunctionAndOptions<Entity>;
+	required: boolean | PropertyBooleanFunction<unknown> | PropertyBooleanFunctionAndOptions<unknown>;
 
 	private _defaultValue: any;
 
@@ -44,7 +44,7 @@ export class Property implements PropertyPath {
 	readonly changed: EventSubscriber<Entity, PropertyChangeEventArgs>;
 	readonly accessed: EventSubscriber<Entity, PropertyAccessEventArgs>;
 
-	constructor(containingType: Type, name: string, propertyType: PropertyType, isIdentifier: boolean, isList: boolean, options?: PropertyOptions<Entity, unknown>) {
+	constructor(containingType: Type, name: string, propertyType: PropertyType, isIdentifier: boolean, isList: boolean, options?: PropertyOptions<unknown, unknown>) {
 		this.containingType = containingType;
 		this.name = name;
 		this.propertyType = propertyType;
@@ -103,7 +103,7 @@ export class Property implements PropertyPath {
 			return getDefaultValue(this.isList, this.propertyType);
 	}
 
-	extend(options: PropertyOptions<Entity, unknown>, targetType?: Type): void {
+	extend(options: PropertyOptions<unknown, unknown>, targetType?: Type): void {
 		if (!targetType)
 			targetType = this.containingType;
 
@@ -159,7 +159,7 @@ export class Property implements PropertyPath {
 				}
 
 				// String Format
-				else if (isType<PropertyFormatOptions<Entity>>(options.format, (f: any) => getTypeName(f) === "object" && f.expression)) {
+				else if (isType<PropertyFormatOptions<unknown>>(options.format, (f: any) => getTypeName(f) === "object" && f.expression)) {
 					let format = options.format;
 					targetType.model.ready(() => {
 						new StringFormatRule(targetType, {
@@ -228,7 +228,7 @@ export class Property implements PropertyPath {
 			// Init
 			if (options.init !== undefined) {
 				let initFn: (this: Entity) => any;
-				if (isPropertyValueFunction<Entity, any>(options.init))
+				if (isPropertyValueFunction<unknown, any>(options.init))
 					initFn = options.init;
 				else
 					throw new Error(`Invalid property 'init' option of type '${getTypeName(options.init)}'.`);
@@ -238,11 +238,11 @@ export class Property implements PropertyPath {
 
 			// Default
 			if (options.default !== undefined) {
-				if (isPropertyValueFunction<Entity, any>(options.default)) {
+				if (isPropertyValueFunction<unknown, any>(options.default)) {
 					// Always generate a rule for default function
 					options.default = { function: options.default, dependsOn: "" };
 				}
-				else if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any>>(options.default)) {
+				else if (isPropertyOptions<PropertyValueFunctionAndOptions<unknown, any>>(options.default)) {
 					// Use default object as specified
 				}
 				else if (options.default === null || isValue(options.default) || isValueArray(options.default)) {
@@ -273,7 +273,7 @@ export class Property implements PropertyPath {
 					throw new Error(`Invalid property 'default' option of type '${getTypeName(options.default)}'.`);
 				}
 
-				if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any>>(options.default)) {
+				if (isPropertyOptions<PropertyValueFunctionAndOptions<unknown, any>>(options.default)) {
 					let defaultOptions = options.default;
 
 					if (typeof (options.default.function) !== "function") {
@@ -300,7 +300,7 @@ export class Property implements PropertyPath {
 					options.get = { function: allowedValuesFunction, dependsOn: "" };
 				}
 
-				if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any[]>>(options.allowedValues)) {
+				if (isPropertyOptions<PropertyValueFunctionAndOptions<unknown, any[]>>(options.allowedValues)) {
 					let allowedValuesOptions = options.allowedValues;
 
 					if (typeof (options.allowedValues.function) !== "function") {
@@ -327,7 +327,7 @@ export class Property implements PropertyPath {
 				let min: (this: Entity) => any;
 
 				if (options.range.min != null) {
-					if (isPropertyValueFunction<Entity, any>(options.range.min)) {
+					if (isPropertyValueFunction<unknown, any>(options.range.min)) {
 						min = options.range.min;
 					}
 					else if (isValue(options.range.min)) {
@@ -342,7 +342,7 @@ export class Property implements PropertyPath {
 				let max: (this: Entity) => any;
 
 				if (options.range.max != null) {
-					if (isPropertyValueFunction<Entity, any>(options.range.max)) {
+					if (isPropertyValueFunction<unknown, any>(options.range.max)) {
 						max = options.range.max;
 					}
 					else if (isValue(options.range.max)) {
@@ -365,7 +365,7 @@ export class Property implements PropertyPath {
 				let min: (this: Entity) => number;
 
 				if (options.length.min != null) {
-					if (isPropertyValueFunction<Entity, any>(options.length.min)) {
+					if (isPropertyValueFunction<unknown, any>(options.length.min)) {
 						min = options.length.min;
 					}
 					else if (isValue<number>(options.length.min, Number)) {
@@ -380,7 +380,7 @@ export class Property implements PropertyPath {
 				let max: (this: Entity) => number;
 
 				if (options.length.max != null) {
-					if (isPropertyValueFunction<Entity, any>(options.length.max)) {
+					if (isPropertyValueFunction<unknown, any>(options.length.max)) {
 						max = options.length.max;
 					}
 					else if (isValue<number>(options.length.max, Number)) {
@@ -425,7 +425,7 @@ export class Property implements PropertyPath {
 					let requiredFn: (this: Entity) => boolean;
 					let requiredMessage: string | ((this: Entity) => string | null | undefined);
 					let requiredDependsOn: string;
-					if (isPropertyOptions<PropertyBooleanFunctionAndOptions<Entity>>(options.required)) {
+					if (isPropertyOptions<PropertyBooleanFunctionAndOptions<unknown>>(options.required)) {
 						requiredFn = options.required.function;
 						requiredMessage = options.required.message;
 						requiredDependsOn = options.required.dependsOn;

--- a/src/property.ts
+++ b/src/property.ts
@@ -908,9 +908,9 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 		// Assign additional collection change event arguments to the property change event
 		var additionalArgs = { changes: args.changes, collectionChanged: true, ...args.additionalArgs };
 
-		(property.containingType.model.listChanged as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
+		(property.containingType.model.listChanged as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
 		(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, merge<PropertyChangeEventArgs>(eventArgs, additionalArgs));
-		(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
+		(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
 	});
 }
 
@@ -942,7 +942,7 @@ export function Property$init(property: Property, obj: Entity, val: any): void {
 	}
 
 	// TODO: Implement observable?
-	(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, { entity: obj, property, newValue: val });
+	(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue: val });
 }
 
 function Property$ensureInited(property: Property, obj: Entity): void {
@@ -976,7 +976,7 @@ function Property$getter(property: Property, obj: Entity): any {
 
 	// Raise access events
 	(property.accessed as EventPublisher<Entity, PropertyAccessEventArgs>).publish(obj, { entity: obj, property, value: obj.__fields__[property.name] });
-	(obj.accessed as Event<Entity, EntityAccessEventArgs<Entity>>).publish(obj, { entity: obj, property });
+	(obj.accessed as Event<Entity, EntityAccessEventArgs>).publish(obj, { entity: obj, property });
 
 	// Return the property value
 	return obj.__fields__[property.name];
@@ -1057,9 +1057,9 @@ function Property$setValue(property: Property, obj: Entity, currentValue: any, n
 		// Do not raise change if the property has not been initialized.
 		if (oldValue !== undefined) {
 			var eventArgs = { entity: obj, property, newValue, oldValue };
-			(property.containingType.model.afterPropertySet as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
+			(property.containingType.model.afterPropertySet as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
 			(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, merge<PropertyChangeEventArgs>(eventArgs, additionalArgs));
-			(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
+			(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
 		}
 	}
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -32,7 +32,7 @@ export class Property implements PropertyPath {
 	helptext: string;
 	isCalculated: boolean;
 	format: Format<any>;
-	required: boolean | PropertyBooleanFunction | PropertyBooleanFunctionAndOptions;
+	required: boolean | PropertyBooleanFunction<Entity> | PropertyBooleanFunctionAndOptions<Entity>;
 
 	private _defaultValue: any;
 
@@ -44,7 +44,7 @@ export class Property implements PropertyPath {
 	readonly changed: EventSubscriber<Entity, PropertyChangeEventArgs>;
 	readonly accessed: EventSubscriber<Entity, PropertyAccessEventArgs>;
 
-	constructor(containingType: Type, name: string, propertyType: PropertyType, isIdentifier: boolean, isList: boolean, options?: PropertyOptions) {
+	constructor(containingType: Type, name: string, propertyType: PropertyType, isIdentifier: boolean, isList: boolean, options?: PropertyOptions<Entity>) {
 		this.containingType = containingType;
 		this.name = name;
 		this.propertyType = propertyType;
@@ -103,7 +103,7 @@ export class Property implements PropertyPath {
 			return getDefaultValue(this.isList, this.propertyType);
 	}
 
-	extend(options: PropertyOptions, targetType?: Type): void {
+	extend(options: PropertyOptions<Entity>, targetType?: Type): void {
 		if (!targetType)
 			targetType = this.containingType;
 
@@ -228,7 +228,7 @@ export class Property implements PropertyPath {
 			// Init
 			if (options.init !== undefined) {
 				let initFn: (this: Entity) => any;
-				if (isPropertyValueFunction<any>(options.init))
+				if (isPropertyValueFunction<Entity, any>(options.init))
 					initFn = options.init;
 				else
 					throw new Error(`Invalid property 'init' option of type '${getTypeName(options.init)}'.`);
@@ -238,11 +238,11 @@ export class Property implements PropertyPath {
 
 			// Default
 			if (options.default !== undefined) {
-				if (isPropertyValueFunction<any>(options.default)) {
+				if (isPropertyValueFunction<Entity, any>(options.default)) {
 					// Always generate a rule for default function
 					options.default = { function: options.default, dependsOn: "" };
 				}
-				else if (isPropertyOptions<PropertyValueFunctionAndOptions<any>>(options.default)) {
+				else if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any>>(options.default)) {
 					// Use default object as specified
 				}
 				else if (options.default === null || isValue(options.default) || isValueArray(options.default)) {
@@ -273,7 +273,7 @@ export class Property implements PropertyPath {
 					throw new Error(`Invalid property 'default' option of type '${getTypeName(options.default)}'.`);
 				}
 
-				if (isPropertyOptions<PropertyValueFunctionAndOptions<any>>(options.default)) {
+				if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any>>(options.default)) {
 					let defaultOptions = options.default;
 
 					if (typeof (options.default.function) !== "function") {
@@ -300,7 +300,7 @@ export class Property implements PropertyPath {
 					options.get = { function: allowedValuesFunction, dependsOn: "" };
 				}
 
-				if (isPropertyOptions<PropertyValueFunctionAndOptions<any[]>>(options.allowedValues)) {
+				if (isPropertyOptions<PropertyValueFunctionAndOptions<Entity, any[]>>(options.allowedValues)) {
 					let allowedValuesOptions = options.allowedValues;
 
 					if (typeof (options.allowedValues.function) !== "function") {
@@ -327,7 +327,7 @@ export class Property implements PropertyPath {
 				let min: (this: Entity) => any;
 
 				if (options.range.min != null) {
-					if (isPropertyValueFunction<any>(options.range.min)) {
+					if (isPropertyValueFunction<Entity, any>(options.range.min)) {
 						min = options.range.min;
 					}
 					else if (isValue(options.range.min)) {
@@ -342,7 +342,7 @@ export class Property implements PropertyPath {
 				let max: (this: Entity) => any;
 
 				if (options.range.max != null) {
-					if (isPropertyValueFunction<any>(options.range.max)) {
+					if (isPropertyValueFunction<Entity, any>(options.range.max)) {
 						max = options.range.max;
 					}
 					else if (isValue(options.range.max)) {
@@ -365,7 +365,7 @@ export class Property implements PropertyPath {
 				let min: (this: Entity) => number;
 
 				if (options.length.min != null) {
-					if (isPropertyValueFunction<any>(options.length.min)) {
+					if (isPropertyValueFunction<Entity, any>(options.length.min)) {
 						min = options.length.min;
 					}
 					else if (isValue<number>(options.length.min, Number)) {
@@ -380,7 +380,7 @@ export class Property implements PropertyPath {
 				let max: (this: Entity) => number;
 
 				if (options.length.max != null) {
-					if (isPropertyValueFunction<any>(options.length.max)) {
+					if (isPropertyValueFunction<Entity, any>(options.length.max)) {
 						max = options.length.max;
 					}
 					else if (isValue<number>(options.length.max, Number)) {
@@ -425,7 +425,7 @@ export class Property implements PropertyPath {
 					let requiredFn: (this: Entity) => boolean;
 					let requiredMessage: string | ((this: Entity) => string);
 					let requiredDependsOn: string;
-					if (isPropertyOptions<PropertyBooleanFunctionAndOptions>(options.required)) {
+					if (isPropertyOptions<PropertyBooleanFunctionAndOptions<Entity>>(options.required)) {
 						requiredFn = options.required.function;
 						requiredMessage = options.required.message;
 						requiredDependsOn = options.required.dependsOn;
@@ -610,7 +610,7 @@ export class Property implements PropertyPath {
 	}
 }
 
-export interface PropertyOptions {
+export interface PropertyOptions<EntityType extends Entity> {
 
 	/** The name or Javascript type of the property */
 	type?: string | PropertyType;
@@ -641,34 +641,34 @@ export interface PropertyOptions {
 	constant?: any;
 
 	/** An optional function or dependency function object that calculates the value of this property. */
-	get?: PropertyValueFunction<any> | PropertyValueFunctionAndOptions<any>;
+	get?: PropertyValueFunction<EntityType, any> | PropertyValueFunctionAndOptions<EntityType, any>;
 
 	/** An optional function to call when this property is updated. */
-	set?: (this: Entity, value: any) => void;
+	set?: (this: EntityType, value: any) => void;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
-	default?: PropertyValueFunction<any> | PropertyValueFunctionAndOptions<any> | Value | Value[];
+	default?: PropertyValueFunction<EntityType, any> | PropertyValueFunctionAndOptions<EntityType, any> | Value | Value[] | null;
 
 	/** A function used to obtain the value with which to initialize this property.
 	 * The function is called only once, and is not reactive as a rule would be.
 	 * Does not overwrite a property value provided during construction of the containing entity.
 	 */
-	init?: PropertyValueFunction<any>;
+	init?: PropertyValueFunction<EntityType, any>;
 
 	/** An optional constant default value, or a function or dependency function object that calculates the default value of this property. */
-	allowedValues?: PropertyValueFunction<any[]> | AllowedValuesFunctionAndOptions<any[]> | Value[];
+	allowedValues?: PropertyValueFunction<EntityType, any[]> | AllowedValuesFunctionAndOptions<EntityType, any[]> | Value[];
 
 	/** True if the property is always required, or a dependency function object for conditionally required properties. */
-	required?: boolean | PropertyBooleanFunction | PropertyBooleanFunctionAndOptions;
+	required?: boolean | PropertyBooleanFunction<EntityType> | PropertyBooleanFunctionAndOptions<EntityType>;
 
 	/** An optional dependency function object that adds an error with the specified message when true. */
 	error?: PropertyErrorFunctionAndOptions | PropertyErrorFunctionAndOptions[];
 
 	/** Optional contant or function-based min and max values. */
-	range?: PropertyRangeOptions<any>;
+	range?: PropertyRangeOptions<EntityType, any>;
 
 	/** Optional contant or function-based min and max length. */
-	length?: PropertyLengthOptions;
+	length?: PropertyLengthOptions<EntityType>;
 }
 
 export interface PropertyFormatOptions {
@@ -693,18 +693,18 @@ export interface PropertyErrorFunctionAndOptions {
 	properties?: string[];
 }
 
-export type PropertyValueFunction<T> = () => T;
+export type PropertyValueFunction<EntityType extends Entity, T> = (this: EntityType) => T;
 
-export interface PropertyValueFunctionAndOptions<T> {
-	function: (this: Entity) => T;
+export interface PropertyValueFunctionAndOptions<EntityType extends Entity, ResultType> {
+	function: (this: EntityType) => ResultType;
 	dependsOn?: string;
 }
 
-export function isPropertyValueFunction<T>(obj: any): obj is PropertyValueFunction<T> {
+export function isPropertyValueFunction<EntityType extends Entity, T>(obj: any): obj is PropertyValueFunction<EntityType, T> {
 	return typeof (obj) === "function";
 }
 
-export interface AllowedValuesFunctionAndOptions<T> extends PropertyValueFunctionAndOptions<T> {
+export interface AllowedValuesFunctionAndOptions<EntityType extends Entity, ResultType> extends PropertyValueFunctionAndOptions<EntityType, ResultType> {
 	ignoreValidation?: boolean;
 	preventInvalidValues?: boolean;
 }
@@ -713,31 +713,31 @@ type LambdaFunction<ReturnType> = () => ReturnType;
 
 type BoundFunction<ThisType, ReturnType> = (this: ThisType) => ReturnType;
 
-export interface PropertyRangeOptions<T> {
-	min?: T | LambdaFunction<T> | BoundFunction<Entity, T>;
-	max?: T | LambdaFunction<T> | BoundFunction<Entity, T>;
+export interface PropertyRangeOptions<EntityType extends Entity, T> {
+	min?: T | LambdaFunction<T> | BoundFunction<EntityType, T>;
+	max?: T | LambdaFunction<T> | BoundFunction<EntityType, T>;
 	dependsOn?: string;
 }
 
-export interface PropertyLengthOptions {
-	min?: number | LambdaFunction<number> | BoundFunction<Entity, number>;
-	max?: number | LambdaFunction<number> | BoundFunction<Entity, number>;
+export interface PropertyLengthOptions<EntityType extends Entity> {
+	min?: number | LambdaFunction<number> | BoundFunction<EntityType, number>;
+	max?: number | LambdaFunction<number> | BoundFunction<EntityType, number>;
 	dependsOn?: string;
 }
 
-export type PropertyBooleanFunction = (this: Entity) => boolean;
+export type PropertyBooleanFunction<EntityType extends Entity>= (this: EntityType) => boolean;
 
-export interface PropertyBooleanFunctionAndOptions {
-	function?: (this: Entity) => boolean;
+export interface PropertyBooleanFunctionAndOptions<EntityType extends Entity> {
+	function?: (this: EntityType) => boolean;
 	dependsOn?: string;
-	message?: string | ((this: Entity) => string);
+	message?: string | ((this: EntityType) => string);
 }
 
-export function isPropertyBooleanFunctionAndOptions(obj: any): obj is PropertyBooleanFunctionAndOptions {
+export function isPropertyBooleanFunctionAndOptions<EntityType extends Entity>(obj: any): obj is PropertyBooleanFunctionAndOptions<EntityType> {
 	return typeof (obj) === "object";
 }
 
-export function isPropertyBooleanFunction(obj: any): obj is PropertyBooleanFunction {
+export function isPropertyBooleanFunction<EntityType extends Entity>(obj: any): obj is PropertyBooleanFunction<EntityType> {
 	return typeof (obj) === "function";
 }
 
@@ -746,7 +746,7 @@ export function isPropertyOptions<TOptions>(obj: any, check: (options: any) => b
 }
 
 export interface PropertyConstructor {
-	new(containingType: Type, name: string, jstype: PropertyType, isList: boolean, options?: PropertyOptions): Property;
+	new(containingType: Type, name: string, jstype: PropertyType, isList: boolean, options?: PropertyOptions<Entity>): Property;
 }
 
 export type PropertyGetMethod = (property: Property, entity: Entity, additionalArgs: any) => any;
@@ -908,9 +908,9 @@ function Property$subArrayEvents(obj: Entity, property: Property, array: Observa
 		// Assign additional collection change event arguments to the property change event
 		var additionalArgs = { changes: args.changes, collectionChanged: true, ...args.additionalArgs };
 
-		(property.containingType.model.listChanged as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
+		(property.containingType.model.listChanged as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
 		(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, merge<PropertyChangeEventArgs>(eventArgs, additionalArgs));
-		(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
+		(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
 	});
 }
 
@@ -942,7 +942,7 @@ export function Property$init(property: Property, obj: Entity, val: any): void {
 	}
 
 	// TODO: Implement observable?
-	(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, { entity: obj, property, newValue: val });
+	(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, { entity: obj, property, newValue: val });
 }
 
 function Property$ensureInited(property: Property, obj: Entity): void {
@@ -973,7 +973,7 @@ function Property$getter(property: Property, obj: Entity): any {
 
 	// Raise access events
 	(property.accessed as EventPublisher<Entity, PropertyAccessEventArgs>).publish(obj, { entity: obj, property, value: obj.__fields__[property.name] });
-	(obj.accessed as Event<Entity, EntityAccessEventArgs>).publish(obj, { entity: obj, property });
+	(obj.accessed as Event<Entity, EntityAccessEventArgs<Entity>>).publish(obj, { entity: obj, property });
 
 	// Return the property value
 	return obj.__fields__[property.name];
@@ -1054,9 +1054,9 @@ function Property$setValue(property: Property, obj: Entity, currentValue: any, n
 		// Do not raise change if the property has not been initialized.
 		if (oldValue !== undefined) {
 			var eventArgs = { entity: obj, property, newValue, oldValue };
-			(property.containingType.model.afterPropertySet as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
+			(property.containingType.model.afterPropertySet as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
 			(property.changed as EventPublisher<Entity, PropertyChangeEventArgs>).publish(obj, merge<PropertyChangeEventArgs>(eventArgs, additionalArgs));
-			(obj.changed as Event<Entity, EntityChangeEventArgs>).publish(obj, merge<EntityChangeEventArgs>(eventArgs, additionalArgs));
+			(obj.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(obj, merge<EntityChangeEventArgs<Entity>>(eventArgs, additionalArgs));
 		}
 	}
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -159,7 +159,7 @@ export class Property implements PropertyPath {
 				}
 
 				// String Format
-				else if (isType<PropertyFormatOptions>(options.format, (f: any) => getTypeName(f) === "object" && f.expression)) {
+				else if (isType<PropertyFormatOptions<Entity>>(options.format, (f: any) => getTypeName(f) === "object" && f.expression)) {
 					let format = options.format;
 					targetType.model.ready(() => {
 						new StringFormatRule(targetType, {
@@ -394,7 +394,7 @@ export class Property implements PropertyPath {
 
 				targetType.model.ready(() => {
 					let onChangeOf: PropertyPath[] = resolveDependsOn(this, "length", options.length.dependsOn);
-					if (isEntityType(this.propertyType)) {
+					if (this.isList) {
 						new ListLengthRule(targetType, { property: this, onChangeOf, min, max }).register();
 					}
 					else {
@@ -423,7 +423,7 @@ export class Property implements PropertyPath {
 				// Conditionally Required
 				else {
 					let requiredFn: (this: Entity) => boolean;
-					let requiredMessage: string | ((this: Entity) => string);
+					let requiredMessage: string | ((this: Entity) => string | null | undefined);
 					let requiredDependsOn: string;
 					if (isPropertyOptions<PropertyBooleanFunctionAndOptions<Entity>>(options.required)) {
 						requiredFn = options.required.function;
@@ -635,7 +635,7 @@ export interface PropertyOptions<EntityType extends Entity> {
 	helptext?: string;
 
 	/** The optional format specifier for the property. */
-	format?: string | Format<PropertyType> | PropertyFormatOptions;
+	format?: string | Format<PropertyType> | PropertyFormatOptions<EntityType>;
 
 	/** A non-null value if the property is constant */
 	constant?: any;
@@ -662,7 +662,7 @@ export interface PropertyOptions<EntityType extends Entity> {
 	required?: boolean | PropertyBooleanFunction<EntityType> | PropertyBooleanFunctionAndOptions<EntityType>;
 
 	/** An optional dependency function object that adds an error with the specified message when true. */
-	error?: PropertyErrorFunctionAndOptions | PropertyErrorFunctionAndOptions[];
+	error?: PropertyErrorFunctionAndOptions<EntityType> | PropertyErrorFunctionAndOptions<EntityType>[];
 
 	/** Optional contant or function-based min and max values. */
 	range?: PropertyRangeOptions<EntityType, any>;
@@ -671,7 +671,7 @@ export interface PropertyOptions<EntityType extends Entity> {
 	length?: PropertyLengthOptions<EntityType>;
 }
 
-export interface PropertyFormatOptions {
+export interface PropertyFormatOptions<EntityType extends Entity> {
 
 	/** The human readable description of the format, such as MM/DD/YYY */
 	description: string;
@@ -682,11 +682,11 @@ export interface PropertyFormatOptions {
 	/** An optional regular expression reformat string that will be used to correct the value if it matches */
 	reformat?: string;
 
-	message?: string | ((this: Entity) => string);
+	message?: string | ((this: EntityType) => string | null | undefined);
 }
 
-export interface PropertyErrorFunctionAndOptions {
-	function: (this: Entity) => string;
+export interface PropertyErrorFunctionAndOptions<EntityType extends Entity> {
+	function: (this: EntityType) => string | null | undefined;
 	dependsOn: string;
 	resource?: string;
 	code?: string;

--- a/src/property.ts
+++ b/src/property.ts
@@ -610,6 +610,7 @@ export class Property implements PropertyPath {
 	}
 }
 
+// TODO: update generic type args
 export interface PropertyOptions<EntityType, P> {
 
 	/** The name or Javascript type of the property */

--- a/src/property.ts
+++ b/src/property.ts
@@ -745,7 +745,7 @@ export function isPropertyOptions<TOptions>(obj: any, check: (options: any) => b
 	return isType<TOptions>(obj, d => getTypeName(d) === "object" && (!check || check(d)));
 }
 
-export interface PropertyConstructor<E extends Type, P> {
+export interface PropertyConstructor<E, P> {
 	new(containingType: TypeOfType<E>, name: string, jstype: PropertyType, isList: boolean, options?: PropertyOptions<E, P>): Property;
 }
 

--- a/src/property.ts
+++ b/src/property.ts
@@ -955,7 +955,10 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 			let setPendingInit = !property.isConstant;
 			Property$init(property, obj, Property$getInitialValue(property));
 			if (property.initializer) {
-				obj.update(property.name, property.initializer.call(obj));
+				const args: ObjectLookup<any> = {};
+				args[property.name] = property.initializer.call(obj);
+				// TODO: Could this just be obj[property.name] = ...?
+				obj.update(args);
 				setPendingInit = false;
 			}
 			// Mark the property as pending initialization if the property value may need to

--- a/src/property.ts
+++ b/src/property.ts
@@ -1,7 +1,7 @@
 import { Event, EventSubscriber, EventPublisher } from "./events";
 import { Entity, EntityChangeEventArgs, EntityAccessEventArgs, EntityOfType } from "./entity";
 import { Format } from "./format";
-import { Type, PropertyType, isEntityType, Value, isValue, isValueArray, ValueConstructorForType, TypeOfType } from "./type";
+import { Type, PropertyType, isEntityType, Value, isValue, isValueArray, TypeOfType, PropertyTypeForType } from "./type";
 import { PropertyChain } from "./property-chain";
 import { getTypeName, getDefaultValue, parseFunctionName, ObjectLookup, merge, getConstructorName, isType, flatMap } from "./helpers";
 import { ObservableArray, updateArray } from "./observable-array";
@@ -613,7 +613,7 @@ export class Property implements PropertyPath {
 export interface PropertyOptions<EntityType, P> {
 
 	/** The name or Javascript type of the property */
-	type: ValueConstructorForType<P> | string | PropertyType;
+	type: string | PropertyTypeForType<P>;
 
 	/**
 	*  The optional label for the property.

--- a/src/property.ts
+++ b/src/property.ts
@@ -956,10 +956,7 @@ function Property$ensureInited(property: Property, obj: Entity): void {
 			let setPendingInit = !property.isConstant;
 			Property$init(property, obj, Property$getInitialValue(property));
 			if (property.initializer) {
-				const args: ObjectLookup<any> = {};
-				args[property.name] = property.initializer.call(obj);
-				// TODO: Could this just be obj[property.name] = ...?
-				obj.update(args);
+				obj.update(property.name, property.initializer.call(obj));
 				setPendingInit = false;
 			}
 			// Mark the property as pending initialization if the property value may need to

--- a/src/property.ts
+++ b/src/property.ts
@@ -1,7 +1,7 @@
 import { Event, EventSubscriber, EventPublisher } from "./events";
 import { Entity, EntityChangeEventArgs, EntityAccessEventArgs, EntityOfType } from "./entity";
 import { Format } from "./format";
-import { Type, PropertyType, isEntityType, Value, isValue, isValueArray, ConstructorForValueType, TypeOfType } from "./type";
+import { Type, PropertyType, isEntityType, Value, isValue, isValueArray, ValueConstructorForType, TypeOfType } from "./type";
 import { PropertyChain } from "./property-chain";
 import { getTypeName, getDefaultValue, parseFunctionName, ObjectLookup, merge, getConstructorName, isType, flatMap } from "./helpers";
 import { ObservableArray, updateArray } from "./observable-array";
@@ -613,7 +613,7 @@ export class Property implements PropertyPath {
 export interface PropertyOptions<EntityType, P> {
 
 	/** The name or Javascript type of the property */
-	type: ConstructorForValueType<P> | string | PropertyType;
+	type: ValueConstructorForType<P> | string | PropertyType;
 
 	/**
 	*  The optional label for the property.

--- a/src/property.ts
+++ b/src/property.ts
@@ -610,7 +610,6 @@ export class Property implements PropertyPath {
 	}
 }
 
-// TODO: update generic type args
 export interface PropertyOptions<TEntity, TProperty> {
 
 	/** The name or Javascript type of the property */

--- a/src/property.ts
+++ b/src/property.ts
@@ -730,7 +730,7 @@ export type PropertyBooleanFunction<EntityType extends Entity>= (this: EntityTyp
 export interface PropertyBooleanFunctionAndOptions<EntityType extends Entity> {
 	function?: (this: EntityType) => boolean;
 	dependsOn?: string;
-	message?: string | ((this: EntityType) => string);
+	message?: string | ((this: EntityType) => string | null | undefined);
 }
 
 export function isPropertyBooleanFunctionAndOptions<EntityType extends Entity>(obj: any): obj is PropertyBooleanFunctionAndOptions<EntityType> {

--- a/src/property.unit.ts
+++ b/src/property.unit.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-new */
 import { createEventObject } from "./events";
-import { Model } from "./model";
+import { Model, createModel } from "./model";
 import { ArrayChangeType } from "./observable-array";
 import { Property$pendingInit } from "./property";
 
@@ -614,8 +614,14 @@ describe("Property", () => {
 		describe("calculated value property", () => {
 			let calcValuePropModel: Model;
 
-			beforeAll(() => {
-				calcValuePropModel = new Model({
+			beforeAll(async () => {
+				calcValuePropModel = await createModel<{
+					Person: {
+						Id: string;
+						Name: string;
+						Email: string;
+					}
+				}>({
 					Person: {
 						Id: {
 							type: String,
@@ -668,8 +674,14 @@ describe("Property", () => {
 		describe("defaulted value property", () => {
 			let defaultedValuePropModel: Model;
 
-			beforeAll(() => {
-				defaultedValuePropModel = new Model({
+			beforeAll(async () => {
+				defaultedValuePropModel = await createModel<{
+					Person: {
+						Id: string;
+						Name: string;
+						Email: string;
+					}
+				}>({
 					Person: {
 						Id: {
 							type: String,

--- a/src/range-rule.unit.ts
+++ b/src/range-rule.unit.ts
@@ -1,9 +1,10 @@
-import { Model } from "./model";
+import { TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 // Import English resources
 import "./resource-en";
 
-function createModel(options) {
+function createModel(options: ModelOptions) {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -13,8 +14,20 @@ function createModel(options) {
 }
 
 describe("RangeRule", () => {
+	type Namespace = {
+		Person: Person;
+	};
+
+	type Person = {
+		FirstName: string;
+		Age: number;
+	};
+
 	it("can be configured with contant min and max values", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -25,9 +38,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ FirstName: "Jane", Age: 50 });
+		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Age = -5;
@@ -49,7 +60,10 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant min value (no max value)", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -60,9 +74,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ FirstName: "Jane", Age: 50 });
+		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = -1;
@@ -77,11 +89,12 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant max value (no min value)", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				FirstName: String,
-				IsAdult: Boolean,
-				IsCentenarian: Boolean,
 				Age: {
 					label: "[FirstName]'s age",
 					type: Number,
@@ -91,9 +104,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ FirstName: "Jane", Age: 1 });
+		var p = new Types.Person({ FirstName: "Jane", Age: 1 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 19;
@@ -112,7 +123,10 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with function min and max values", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -126,9 +140,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ FirstName: "Jane", Age: 50 });
+		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 17;
@@ -150,7 +162,21 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with dynamic function min and max values", async () => {
-		const model = await createModel({
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Namespace = {
+			Person: Person;
+		};
+
+		type Person = {
+			FirstName: string;
+			IsAdult: boolean;
+			IsCentenarian: boolean;
+			Age: number;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				FirstName: String,
 				IsAdult: {
@@ -174,9 +200,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ FirstName: "Jane", Age: 50 });
+		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 17;

--- a/src/range-rule.unit.ts
+++ b/src/range-rule.unit.ts
@@ -1,33 +1,17 @@
-import { TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { createModel } from "./model";
 
 // Import English resources
 import "./resource-en";
 
-function createModel(options: ModelOptions) {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("RangeRule", () => {
-	type Namespace = {
-		Person: Person;
-	};
-
 	type Person = {
 		FirstName: string;
 		Age: number;
 	};
 
 	it("can be configured with contant min and max values", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { $namespace: Types } = await createModel<{ Person: Person }>({
+			$namespace: {} as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -60,10 +44,8 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant min value (no max value)", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { $namespace: Types } = await createModel<{ Person: Person }>({
+			$namespace: {} as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -89,10 +71,8 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant max value (no min value)", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { $namespace: Types } = await createModel<{ Person: Person }>({
+			$namespace: {} as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -123,10 +103,8 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with function min and max values", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		await createModel({
-			$namespace: Types as any,
+		const { $namespace: Types } = await createModel<{ Person: Person }>({
+			$namespace: {} as any,
 			Person: {
 				FirstName: String,
 				Age: {
@@ -162,12 +140,6 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with dynamic function min and max values", async () => {
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Namespace = {
-			Person: Person;
-		};
-
 		type Person = {
 			FirstName: string;
 			IsAdult: boolean;
@@ -175,8 +147,8 @@ describe("RangeRule", () => {
 			Age: number;
 		};
 
-		await createModel({
-			$namespace: Types as any,
+		const { $namespace: Types } = await createModel<{ Person: Person }>({
+			$namespace: {} as any,
 			Person: {
 				FirstName: String,
 				IsAdult: {

--- a/src/range-rule.unit.ts
+++ b/src/range-rule.unit.ts
@@ -10,8 +10,7 @@ describe("RangeRule", () => {
 	};
 
 	it("can be configured with contant min and max values", async () => {
-		const { $namespace: Types } = await createModel<{ Person: Person }>({
-			$namespace: {} as any,
+		const { Person } = await createModel<{ Person: Person }>({
 			Person: {
 				FirstName: String,
 				Age: {
@@ -22,7 +21,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
+		var p = new Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Age = -5;
@@ -44,8 +43,7 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant min value (no max value)", async () => {
-		const { $namespace: Types } = await createModel<{ Person: Person }>({
-			$namespace: {} as any,
+		const { Person } = await createModel<{ Person: Person }>({
 			Person: {
 				FirstName: String,
 				Age: {
@@ -56,7 +54,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
+		var p = new Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = -1;
@@ -71,8 +69,7 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with a constant max value (no min value)", async () => {
-		const { $namespace: Types } = await createModel<{ Person: Person }>({
-			$namespace: {} as any,
+		const { Person } = await createModel<{ Person: Person }>({
 			Person: {
 				FirstName: String,
 				Age: {
@@ -84,7 +81,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ FirstName: "Jane", Age: 1 });
+		var p = new Person({ FirstName: "Jane", Age: 1 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 19;
@@ -103,8 +100,7 @@ describe("RangeRule", () => {
 	});
 
 	it("can be configured with function min and max values", async () => {
-		const { $namespace: Types } = await createModel<{ Person: Person }>({
-			$namespace: {} as any,
+		const { Person } = await createModel<{ Person: Person }>({
 			Person: {
 				FirstName: String,
 				Age: {
@@ -118,7 +114,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
+		var p = new Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 17;
@@ -147,8 +143,7 @@ describe("RangeRule", () => {
 			Age: number;
 		};
 
-		const { $namespace: Types } = await createModel<{ Person: Person }>({
-			$namespace: {} as any,
+		const { Person } = await createModel<{ Person: Person }>({
 			Person: {
 				FirstName: String,
 				IsAdult: {
@@ -172,7 +167,7 @@ describe("RangeRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ FirstName: "Jane", Age: 50 });
+		var p = new Person({ FirstName: "Jane", Age: 50 });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Age = 17;

--- a/src/required-rule.unit.ts
+++ b/src/required-rule.unit.ts
@@ -1,8 +1,9 @@
-import { Model } from "./model";
+import { EntityOfType, TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 import "./resource-en";
 
-function createModel(options) {
+function createModel(options: ModelOptions) {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -13,16 +14,27 @@ function createModel(options) {
 
 describe("RequiredRule", () => {
 	test("Required boolean", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Text: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Text: {
 					required: true,
 					type: String
 				}
 			}
-		}) as any;
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		});
+
+		const t = new Types.Test();
 		expect(t.meta.conditions.length).toBe(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Text is required.");
 		t.Text = "A";
@@ -30,7 +42,19 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Text1: string;
+			Text2: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Text1: {
 					required: {
@@ -43,10 +67,9 @@ describe("RequiredRule", () => {
 					type: String
 				}
 			}
-		}) as any;
+		});
 
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		const t = new Types.Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);
@@ -56,12 +79,24 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required message function", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Text1: string;
+			Text2: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Text1: {
 					required: {
 						dependsOn: "Text2",
-						message() {
+						message(this: EntityOfType<Test>) {
 							if (!this.Text1 && this.Text2)
 								return "Custom required.";
 						},
@@ -75,10 +110,9 @@ describe("RequiredRule", () => {
 					type: String
 				}
 			}
-		}) as any;
+		});
 
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		const t = new Types.Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);
@@ -88,7 +122,19 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function with custom message", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Text1: string;
+			Text2: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Text1: {
 					required: {
@@ -102,10 +148,9 @@ describe("RequiredRule", () => {
 					type: String
 				}
 			}
-		}) as any;
+		});
 
-		const Test = model.getJsType("Test");
-		const t = new Test();
+		const t = new Types.Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);

--- a/src/required-rule.unit.ts
+++ b/src/required-rule.unit.ts
@@ -1,10 +1,10 @@
-import { Model } from "./model";
+import { createModel } from "./model";
 
 import "./resource-en";
 
 describe("RequiredRule", () => {
 	test("Required boolean", async () => {
-		const { Test } = await Model.create<{
+		const { Test } = await createModel<{
 			Test: {
 				Text: string;
 			}
@@ -25,7 +25,7 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function", async () => {
-		const { Test } = await Model.create<{
+		const { Test } = await createModel<{
 			Test: {
 				Text1: string;
 				Text2: string;
@@ -55,7 +55,7 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required message function", async () => {
-		const { Test } = await Model.create<{
+		const { Test } = await createModel<{
 			Test: {
 				Text1: string;
 				Text2: string;
@@ -91,7 +91,7 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function with custom message", async () => {
-		const { Test } = await Model.create<{
+		const { Test } = await createModel<{
 			Test: {
 				Text1: string;
 				Text2: string;

--- a/src/required-rule.unit.ts
+++ b/src/required-rule.unit.ts
@@ -1,31 +1,14 @@
-import { EntityOfType, TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { Model } from "./model";
 
 import "./resource-en";
 
-function createModel(options: ModelOptions) {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("RequiredRule", () => {
 	test("Required boolean", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Text: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await Model.create<{
+			Test: {
+				Text: string;
+			}
+		}>({
 			Test: {
 				Text: {
 					required: true,
@@ -34,7 +17,7 @@ describe("RequiredRule", () => {
 			}
 		});
 
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions.length).toBe(1);
 		expect(t.meta.conditions[0].condition.message).toBe("Text is required.");
 		t.Text = "A";
@@ -42,19 +25,12 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Text1: string;
-			Text2: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await Model.create<{
+			Test: {
+				Text1: string;
+				Text2: string;
+			}
+		}>({
 			Test: {
 				Text1: {
 					required: {
@@ -69,7 +45,7 @@ describe("RequiredRule", () => {
 			}
 		});
 
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);
@@ -79,24 +55,17 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required message function", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Text1: string;
-			Text2: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await Model.create<{
+			Test: {
+				Text1: string;
+				Text2: string;
+			};
+		}>({
 			Test: {
 				Text1: {
 					required: {
 						dependsOn: "Text2",
-						message(this: EntityOfType<Test>) {
+						message() {
 							if (!this.Text1 && this.Text2)
 								return "Custom required.";
 						},
@@ -112,7 +81,7 @@ describe("RequiredRule", () => {
 			}
 		});
 
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);
@@ -122,19 +91,12 @@ describe("RequiredRule", () => {
 	});
 
 	test("Required function with custom message", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Text1: string;
-			Text2: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await Model.create<{
+			Test: {
+				Text1: string;
+				Text2: string;
+			}
+		}>({
 			Test: {
 				Text1: {
 					required: {
@@ -150,7 +112,7 @@ describe("RequiredRule", () => {
 			}
 		});
 
-		const t = new Types.Test();
+		const t = new Test();
 		expect(t.meta.conditions.length).toBe(0);
 		t.Text2 = "A";
 		expect(t.meta.conditions.length).toBe(1);

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -1,4 +1,4 @@
-import { Entity, EntityConstructorForType, EntityChangeEventArgs } from "./entity";
+import { Entity, EntityConstructor, EntityChangeEventArgs } from "./entity";
 import { PropertyPath } from "./property-path";
 import { Property$pendingInit, Property } from "./property";
 import { Event } from "./events";
@@ -234,7 +234,7 @@ export class Rule {
 							rule.eventScope.onExit(e => {
 								if (!e.abort) {
 									rule.returnValues.forEach((returnValue) => {
-										(args.entity.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
+										(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
 									});
 								}
 							});
@@ -260,7 +260,7 @@ export interface RuleOptions {
 	/** Array of properties (strings or Property instances) that the rule is responsible for calculating */
 	returns?: Property[];
 
-	rootType?: EntityConstructorForType<Entity>;
+	rootType?: EntityConstructor;
 }
 
 export interface RuleInvocationOptions {

--- a/src/rule.ts
+++ b/src/rule.ts
@@ -17,7 +17,7 @@ export class Rule {
 	readonly rootType: Type;
 	readonly name: string;
 
-	invocationTypes: RuleInvocationType = 0;
+	invocationTypes: RuleInvocationType = 0 as any;
 	predicates: PropertyPath[] = [];
 	returnValues: Property[] = [];
 
@@ -234,7 +234,7 @@ export class Rule {
 							rule.eventScope.onExit(e => {
 								if (!e.abort) {
 									rule.returnValues.forEach((returnValue) => {
-										(args.entity.changed as Event<Entity, EntityChangeEventArgs>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
+										(args.entity.changed as Event<Entity, EntityChangeEventArgs<Entity>>).publish(args.entity, { entity: args.entity, property: returnValue, newValue: returnValue.value(args.entity) });
 									});
 								}
 							});

--- a/src/string-format-rule.unit.ts
+++ b/src/string-format-rule.unit.ts
@@ -1,27 +1,10 @@
-import { TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { createModel } from "./model";
 
 // Import English resources
 import "./resource-en";
 
-function createModel(options: ModelOptions): Promise<Model> {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("StringFormatRule", ()=>{
 	it("format", async () => {
-		type Namespace = {
-			Name: Name;
-			Person: Person;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
 		type Name = {
 			First: string;
 			Last: string;
@@ -31,8 +14,10 @@ describe("StringFormatRule", ()=>{
 			Name: Name;
 		};
 
-		await createModel({
-			$namespace: Types as any,
+		const { Person } = await createModel<{
+			Name: Name;
+			Person: Person;
+		}>({
 			Name: {
 				First: String,
 				Last: String
@@ -44,24 +29,16 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-
-		const p = new Types.Person({ Name: { First: "John", Last: "Doe" } });
+		const p = new Person({ Name: { First: "John", Last: "Doe" } });
 		expect(p.toString("[Name]")).toBe("John Doe");
 	});
 
 	it("Description, reformat, expression", async () => {
-		type Namespace = {
-			Test: Test;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Test = {
-			Phone: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Test } = await createModel<{
+			Test: {
+				Phone: string;
+			}
+		}>({
 			Test: {
 				Phone: {
 					format: {
@@ -73,8 +50,7 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-
-		const p = new Types.Test({ Phone: "1234567890" });
+		const p = new Test({ Phone: "1234567890" });
 		expect(p.toString("[Phone]")).toBe("(123) 456-7890");
 		p.Phone = "1234567890x1234";
 		expect(p.toString("[Phone]")).toBe("(123) 456-7890x1234");

--- a/src/string-format-rule.unit.ts
+++ b/src/string-format-rule.unit.ts
@@ -3,7 +3,7 @@ import { Model } from "./model";
 
 // Import English resources
 import "./resource-en";
-import { EntityType } from "./type";
+import { ReferenceType } from "./type";
 
 function createModel(options): Promise<Model> {
 	return new Promise((resolve) => {
@@ -28,7 +28,7 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-		const Person = model.getJsType("Person") as EntityType;
+		const Person = model.getJsType("Person") as ReferenceType;
 		const p = new Person({ Name: { First: "John", Last: "Doe" } });
 		expect(p.toString("[Name]")).toBe("John Doe");
 	});

--- a/src/string-format-rule.unit.ts
+++ b/src/string-format-rule.unit.ts
@@ -1,9 +1,11 @@
+import { EntityConstructorForType, EntityOfType, TEntityConstructor } from "./entity";
 import { Model } from "./model";
 
 // Import English resources
 import "./resource-en";
+import { EntityType } from "./type";
 
-function createModel(options) {
+function createModel(options): Promise<Model> {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -26,13 +28,24 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-		const Person = model.getJsType("Person");
+		const Person = model.getJsType("Person") as EntityType;
 		const p = new Person({ Name: { First: "John", Last: "Doe" } });
 		expect(p.toString("[Name]")).toBe("John Doe");
 	});
 
 	it("Description, reformat, expression", async () => {
+		type Namespace = {
+			Test: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Test = {
+			Phone: string;
+		};
+
 		const model = await createModel({
+			$namespace: Types,
 			Test: {
 				Phone: {
 					format: {
@@ -44,7 +57,7 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-		const Test = model.getJsType("Test");
+		const Test = model.getJsType("Test") as EntityConstructorForType<EntityOfType<Test>>;
 		const p = new Test({ Phone: "1234567890" });
 		expect(p.toString("[Phone]")).toBe("(123) 456-7890");
 		p.Phone = "1234567890x1234";

--- a/src/string-format-rule.unit.ts
+++ b/src/string-format-rule.unit.ts
@@ -1,11 +1,10 @@
-import { EntityConstructorForType, EntityOfType, TEntityConstructor } from "./entity";
-import { Model } from "./model";
+import { TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 // Import English resources
 import "./resource-en";
-import { ReferenceType } from "./type";
 
-function createModel(options): Promise<Model> {
+function createModel(options: ModelOptions): Promise<Model> {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -16,7 +15,24 @@ function createModel(options): Promise<Model> {
 
 describe("StringFormatRule", ()=>{
 	it("format", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Name: Name;
+			Person: Person;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Name = {
+			First: string;
+			Last: string;
+		};
+
+		type Person = {
+			Name: Name;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Name: {
 				First: String,
 				Last: String
@@ -28,8 +44,8 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-		const Person = model.getJsType("Person") as ReferenceType;
-		const p = new Person({ Name: { First: "John", Last: "Doe" } });
+
+		const p = new Types.Person({ Name: { First: "John", Last: "Doe" } });
 		expect(p.toString("[Name]")).toBe("John Doe");
 	});
 
@@ -44,8 +60,8 @@ describe("StringFormatRule", ()=>{
 			Phone: string;
 		};
 
-		const model = await createModel({
-			$namespace: Types,
+		await createModel({
+			$namespace: Types as any,
 			Test: {
 				Phone: {
 					format: {
@@ -57,8 +73,8 @@ describe("StringFormatRule", ()=>{
 				}
 			}
 		});
-		const Test = model.getJsType("Test") as EntityConstructorForType<EntityOfType<Test>>;
-		const p = new Test({ Phone: "1234567890" });
+
+		const p = new Types.Test({ Phone: "1234567890" });
 		expect(p.toString("[Phone]")).toBe("(123) 456-7890");
 		p.Phone = "1234567890x1234";
 		expect(p.toString("[Phone]")).toBe("(123) 456-7890x1234");

--- a/src/string-length-rule.unit.ts
+++ b/src/string-length-rule.unit.ts
@@ -1,32 +1,15 @@
-import { TEntityConstructor } from "./entity";
-import { Model, ModelOptions } from "./model";
+import { createModel } from "./model";
 
 // Import English resources
 import "./resource-en";
 
-function createModel(options: ModelOptions) {
-	return new Promise((resolve) => {
-		let model = new Model(options);
-		model.ready(() => {
-			resolve(model);
-		});
-	});
-}
-
 describe("StringLengthRule", () => {
 	it("can be configured with contant min and max length", async () => {
-		type Namespace = {
-			Person: Person;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Person = {
-			Name: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Person } = await createModel<{
+			Person: {
+				Name: string;
+			}
+		}>({
 			Person: {
 				Name: {
 					type: String,
@@ -35,7 +18,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ Name: "Jane" });
+		var p = new Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -55,18 +38,11 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with a constant min value (no max value)", async () => {
-		type Namespace = {
-			Person: Person;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Person = {
-			Name: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Person } = await createModel<{
+			Person: {
+				Name: string;
+			}
+		}>({
 			Person: {
 				Name: {
 					type: String,
@@ -75,7 +51,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ Name: "Jane" });
+		var p = new Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -87,18 +63,11 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with a constant max value (no min value)", async () => {
-		type Namespace = {
-			Person: Person;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Person = {
-			Name: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Person } = await createModel<{
+			Person: {
+				Name: string;
+			}
+		}>({
 			Person: {
 				Name: {
 					type: String,
@@ -107,7 +76,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ Name: "Jane" });
+		var p = new Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -119,19 +88,12 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with dynamic function min and max values", async () => {
-		type Namespace = {
-			Person: Person;
-		};
-
-		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
-
-		type Person = {
-			IsFullName: boolean;
-			Name: string;
-		};
-
-		await createModel({
-			$namespace: Types as any,
+		const { Person } = await createModel<{
+			Person: {
+				IsFullName: boolean;
+				Name: string;
+			}
+		}>({
 			Person: {
 				IsFullName: Boolean,
 				Name: {
@@ -149,7 +111,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		var p = new Types.Person({ Name: "Jane" });
+		var p = new Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Name = "J";

--- a/src/string-length-rule.unit.ts
+++ b/src/string-length-rule.unit.ts
@@ -1,9 +1,10 @@
-import { Model } from "./model";
+import { TEntityConstructor } from "./entity";
+import { Model, ModelOptions } from "./model";
 
 // Import English resources
 import "./resource-en";
 
-function createModel(options) {
+function createModel(options: ModelOptions) {
 	return new Promise((resolve) => {
 		let model = new Model(options);
 		model.ready(() => {
@@ -14,7 +15,18 @@ function createModel(options) {
 
 describe("StringLengthRule", () => {
 	it("can be configured with contant min and max length", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Person: Person;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Person = {
+			Name: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				Name: {
 					type: String,
@@ -23,9 +35,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ Name: "Jane" });
+		var p = new Types.Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -45,7 +55,18 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with a constant min value (no max value)", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Person: Person;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Person = {
+			Name: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				Name: {
 					type: String,
@@ -54,9 +75,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ Name: "Jane" });
+		var p = new Types.Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -68,7 +87,18 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with a constant max value (no min value)", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Person: Person;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Person = {
+			Name: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				Name: {
 					type: String,
@@ -77,9 +107,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ Name: "Jane" });
+		var p = new Types.Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially within range
 
 		p.Name = "J";
@@ -91,7 +119,19 @@ describe("StringLengthRule", () => {
 	});
 
 	it("can be configured with dynamic function min and max values", async () => {
-		const model = await createModel({
+		type Namespace = {
+			Person: Person;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
+		type Person = {
+			IsFullName: boolean;
+			Name: string;
+		};
+
+		await createModel({
+			$namespace: Types as any,
 			Person: {
 				IsFullName: Boolean,
 				Name: {
@@ -109,9 +149,7 @@ describe("StringLengthRule", () => {
 			}
 		});
 
-		const Person = model.getJsType("Person");
-
-		var p = new Person({ Name: "Jane" });
+		var p = new Types.Person({ Name: "Jane" });
 		expect(p.meta.conditions.length).toBe(0); // initially in range
 
 		p.Name = "J";

--- a/src/type.ts
+++ b/src/type.ts
@@ -503,8 +503,8 @@ export class Type {
 }
 
 export type Value = string | number | Date | boolean;
-export type ValueType = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
-export type PropertyType = ValueType | EntityConstructor | ObjectConstructor;
+export type ValueConstructor = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
+export type PropertyType = ValueConstructor | EntityConstructor | ObjectConstructor;
 
 export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
@@ -549,11 +549,11 @@ export type TypeExtensionOptions<EntityType> = {
 
 export type TypeOptions<EntityType> = TypeBasicOptions & TypeExtensionOptions<EntityType>;
 
-export function isValueType(type: any): type is ValueType {
+export function isValueType(type: any): type is ValueConstructor {
 	return type === String || type === Number || type === Date || type === Boolean;
 }
 
-export function isValue<T = Value | string | number | Date | boolean>(value: any, type: ValueType = null): value is T {
+export function isValue<T = Value | string | number | Date | boolean>(value: any, type: ValueConstructor = null): value is T {
 	if (value == null)
 		return false;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -516,8 +516,8 @@ interface TypeBasicOptions {
 	$format?: string | Format<Entity>;
 }
 
-export interface RuleOrMethodOptions<TEntity extends Entity> {
-	function: (this: TEntity, ...args: any[]) => any;
+export interface RuleOrMethodOptions<EntityType extends Entity> {
+	function: (this: EntityType, ...args: any[]) => any;
 	dependsOn?: string;
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -18,7 +18,7 @@ export class Type {
 	// changed without fundamentally changing what it represents
 	readonly model: Model;
 	readonly fullName: string;
-	readonly jstype: EntityType;
+	readonly jstype: ReferenceType;
 	readonly baseType: Type;
 	readonly derivedTypes: Type[];
 
@@ -504,8 +504,8 @@ export class Type {
 
 export type Value = string | number | Date | boolean;
 export type ValueType = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
-export type EntityType = EntityConstructorForType<Entity>;
-export type PropertyType = ValueType | EntityType | ObjectConstructor;
+export type ReferenceType = EntityConstructorForType<Entity>;
+export type PropertyType = ValueType | ReferenceType | ObjectConstructor;
 
 export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
@@ -576,7 +576,7 @@ export function isValueArray(value: any): value is Value[] {
 	return isValueType(itemType);
 }
 
-export function isEntityType(type: any): type is EntityType {
+export function isEntityType(type: any): type is ReferenceType {
 	return type.meta && type.meta instanceof Type;
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -511,7 +511,7 @@ export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
 }
 
-type TypeOfTypeMemberOverrides<T> = {
+export interface TypeOfType<T> extends Type {
 	readonly initNew: EventSubscriber<TypeOfType<T>, EntityInitNewEventArgs<EntityOfType<T>>>;
 	readonly initExisting: EventSubscriber<TypeOfType<T>, EntityInitExistingEventArgs<EntityOfType<T>>>;
 	createIfNotExists(state: any): EntityOfType<T>;
@@ -522,9 +522,7 @@ type TypeOfTypeMemberOverrides<T> = {
 	get(id: string, exactTypeOnly?: boolean): EntityOfType<T>;
 	known(): EntityOfType<T>[];
 	addRule(optionsOrFunction: ((this: EntityOfType<T>) => void) | RuleOptions): Rule;
-};
-
-export type TypeOfType<T> = TypeOfTypeMemberOverrides<T> & Type; // Omit<Type, keyof TypeOfTypeMemberOverrides<T>> &
+}
 
 interface TypeBasicOptions {
 	$extends?: string;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,5 @@
 import { Model } from "./model";
-import { Entity, EntityInitNewEventArgs, EntityInitExistingEventArgs, EntityRegisteredEventArgs, EntityConstructor, EntityOfType, EntityInitNewEventArgsForType, EntityInitExistingEventArgsForType, EntityConstructorForType } from "./entity";
+import { Entity, EntityInitNewEventArgs, EntityInitExistingEventArgs, EntityRegisteredEventArgs, EntityConstructor, EntityOfType, EntityInitNewEventArgsForType, EntityInitExistingEventArgsForType, EntityConstructorForType, EntityArgsOfType } from "./entity";
 import { Property, PropertyOptions, Property$generateOwnProperty, Property$generatePrototypeProperty, Property$generateShortcuts } from "./property";
 import { navigateAttribute, getTypeName, parseFunctionName, ensureNamespace, getGlobalObject, entries } from "./helpers";
 import { Event, EventSubscriber } from "./events";
@@ -524,14 +524,19 @@ export interface TypeOfType<T> extends Type {
 	readonly jstype: EntityConstructorForType<T>;
 	readonly initNew: EventSubscriber<TypeOfType<T>, EntityInitNewEventArgsForType<T>>;
 	readonly initExisting: EventSubscriber<TypeOfType<T>, EntityInitExistingEventArgsForType<T>>;
+	createIfNotExists(state: EntityArgsOfType<T>): EntityOfType<T>;
 	createIfNotExists(state: any): EntityOfType<T>;
+	createSync(state: EntityArgsOfType<T>): EntityOfType<T>;
 	createSync(state: any): EntityOfType<T>;
+	create(state: EntityArgsOfType<T>): Promise<EntityOfType<T>>;
 	create(state: any): Promise<EntityOfType<T>>;
 	register(obj: EntityOfType<T>): void;
 	changeObjectId(oldId: string, newId: string): EntityOfType<T> | void;
 	get(id: string, exactTypeOnly?: boolean): EntityOfType<T>;
 	known(): EntityOfType<T>[];
 	addRule(optionsOrFunction: ((this: EntityOfType<T>) => void) | RuleOptions): Rule;
+	extend(options: TypeExtensionOptionsForType<Partial<T>>): void;
+	extend(options: TypeExtensionOptionsForType<unknown>): void;
 }
 
 interface TypeBasicOptions {

--- a/src/type.ts
+++ b/src/type.ts
@@ -553,7 +553,7 @@ export function isValueType(type: any): type is ValueConstructor {
 	return type === String || type === Number || type === Date || type === Boolean;
 }
 
-export function isValue<T = Value | string | number | Date | boolean>(value: any, type: ValueConstructor = null): value is T {
+export function isValue<T = Value>(value: any, type: ValueConstructor = null): value is T {
 	if (value == null)
 		return false;
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -40,7 +40,7 @@ export class Type {
 	readonly initExisting: EventSubscriber<Type, EntityInitExistingEventArgs>;
 	// readonly conditionsChanged: EventSubscriber<Type, ConditionTargetsChangedEventArgs>;
 
-	constructor(model: Model, fullName: string, baseType: Type = null, format: string | Format<Entity>, options?: TypeExtensionOptions<Entity>) {
+	constructor(model: Model, fullName: string, baseType: Type = null, format: string | Format<Entity>, options?: TypeExtensionOptions<unknown>) {
 		this.model = model;
 		this.fullName = fullName;
 		this.jstype = Type$generateConstructor(this, fullName, baseType, model.settings.useGlobalObject ? getGlobalObject() : null);
@@ -410,7 +410,7 @@ export class Type {
 
 		// Use prepare() to defer property path resolution while the model is being extended
 		this.model.prepare(() => {
-			const isRuleMethod = (value: any): value is RuleOrMethodOptions<Entity> => value.hasOwnProperty("function");
+			const isRuleMethod = (value: any): value is RuleOrMethodOptions<unknown> => value.hasOwnProperty("function");
 
 			// Type Members
 			for (let [name, member] of entries(options)) {
@@ -448,7 +448,7 @@ export class Type {
 
 				// Property
 				else {
-					member = { ...member } as PropertyOptions<Entity, any>;
+					member = { ...member } as PropertyOptions<unknown, any>;
 
 					// Get Property
 					let property = this.getProperty(name);

--- a/src/type.ts
+++ b/src/type.ts
@@ -503,7 +503,15 @@ export class Type {
 }
 
 export type Value = string | number | Date | boolean;
+
 export type ValueConstructor = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
+export type ValueConstructorForType<T> =
+	T extends string ? StringConstructor :
+	T extends number ? NumberConstructor :
+	T extends boolean ? BooleanConstructor :
+	T extends Date ? DateConstructor :
+	never;
+
 export type PropertyType = ValueConstructor | EntityConstructor | ObjectConstructor;
 
 export interface TypeConstructor {
@@ -536,15 +544,8 @@ export interface RuleOrMethodOptions<EntityType> {
 
 export type RuleOrMethodFunctionOrOptions<EntityType> = ((this: EntityOfType<EntityType>, ...args: any[]) => any) | RuleOrMethodOptions<EntityType>;
 
-export type ConstructorForValueType<T> =
-	T extends string ? StringConstructor :
-	T extends number ? NumberConstructor :
-	T extends boolean ? BooleanConstructor :
-	T extends Date ? DateConstructor :
-	string;
-
 export type TypeExtensionOptions<EntityType> = {
-	[P in keyof EntityType]: ConstructorForValueType<EntityType[P]> | string | PropertyOptions<EntityType, EntityType[P]> | RuleOrMethodFunctionOrOptions<EntityType>;
+	[P in keyof EntityType]: ValueConstructorForType<EntityType[P]> | string | PropertyOptions<EntityType, EntityType[P]> | RuleOrMethodFunctionOrOptions<EntityType>;
 }
 
 export type TypeOptions<EntityType> = TypeBasicOptions & TypeExtensionOptions<EntityType>;

--- a/src/type.ts
+++ b/src/type.ts
@@ -391,7 +391,7 @@ export class Type {
 	 * Extends the current type with the specified format, properties and methods
 	 * @param options The options specifying how to extend the type
 	 */
-	extend(options: TypeExtensionOptions<Entity>): void {
+	extend(options: TypeExtensionOptions<any>): void {
 		let type = this;
 
 		// Utility function to convert a path string into a resolved array of Property and PropertyChain instances
@@ -448,7 +448,7 @@ export class Type {
 
 				// Property
 				else {
-					member = { ...member } as PropertyOptions<Entity>;
+					member = { ...member } as PropertyOptions<Entity, any>;
 
 					// Get Property
 					let property = this.getProperty(name);
@@ -529,18 +529,25 @@ interface TypeBasicOptions {
 	$format?: string | Format<Entity>;
 }
 
-export interface RuleOrMethodOptions<EntityType extends Entity> {
-	function: (this: EntityType, ...args: any[]) => any;
+export interface RuleOrMethodOptions<EntityType> {
+	function: (this: EntityOfType<EntityType>, ...args: any[]) => any;
 	dependsOn?: string;
 }
 
-export type RuleOrMethodFunctionOrOptions<EntityType extends Entity> = ((this: EntityType, ...args: any[]) => any) | RuleOrMethodOptions<EntityType>;
+export type RuleOrMethodFunctionOrOptions<EntityType> = ((this: EntityOfType<EntityType>, ...args: any[]) => any) | RuleOrMethodOptions<EntityType>;
 
-export interface TypeExtensionOptions<EntityType extends Entity> {
-	[name: string]: string | ValueType | PropertyOptions<EntityType> | RuleOrMethodFunctionOrOptions<EntityType>;
+export type ConstructorForValueType<T> =
+	T extends string ? StringConstructor :
+	T extends number ? NumberConstructor :
+	T extends boolean ? BooleanConstructor :
+	T extends Date ? DateConstructor :
+	string;
+
+export type TypeExtensionOptions<EntityType> = {
+	[P in keyof EntityType]: ConstructorForValueType<EntityType[P]> | string | PropertyOptions<EntityType, EntityType[P]> | RuleOrMethodFunctionOrOptions<EntityType>;
 }
 
-export type TypeOptions<EntityType extends Entity> = TypeBasicOptions & TypeExtensionOptions<EntityType>;
+export type TypeOptions<EntityType> = TypeBasicOptions & TypeExtensionOptions<EntityType>;
 
 export function isValueType(type: any): type is ValueType {
 	return type === String || type === Number || type === Date || type === Boolean;

--- a/src/type.ts
+++ b/src/type.ts
@@ -514,6 +514,8 @@ export type ValueConstructorForType<T> =
 
 export type PropertyType = ValueConstructor | EntityConstructor | ObjectConstructor;
 
+export type PropertyTypeForType<T> = ValueConstructorForType<T> | EntityConstructorForType<T> | ObjectConstructor;
+
 export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -544,18 +544,18 @@ interface TypeBasicOptions {
 	$format?: string | Format<Entity>;
 }
 
-export interface RuleOrMethodOptions<EntityType> {
-	function: (this: EntityOfType<EntityType>, ...args: any[]) => any;
+export interface RuleOrMethodOptions<TEntity> {
+	function: (this: EntityOfType<TEntity>, ...args: any[]) => any;
 	dependsOn?: string;
 }
 
-export type RuleOrMethodFunctionOrOptions<EntityType> = ((this: EntityOfType<EntityType>, ...args: any[]) => any) | RuleOrMethodOptions<EntityType>;
+export type RuleOrMethodFunctionOrOptions<TEntity> = ((this: EntityOfType<TEntity>, ...args: any[]) => any) | RuleOrMethodOptions<TEntity>;
 
-export type TypeExtensionOptionsForType<EntityType> = {
-	[P in keyof EntityType]: ValueConstructorForType<EntityType[P]> | string | PropertyOptions<EntityType, EntityType[P]> | RuleOrMethodFunctionOrOptions<EntityType>;
+export type TypeExtensionOptionsForType<TEntity> = {
+	[P in keyof TEntity]: ValueConstructorForType<TEntity[P]> | string | PropertyOptions<TEntity, TEntity[P]> | RuleOrMethodFunctionOrOptions<TEntity>;
 }
 
-export type TypeOptionsForType<EntityType> = TypeBasicOptions & TypeExtensionOptionsForType<EntityType>;
+export type TypeOptionsForType<TEntity> = TypeBasicOptions & TypeExtensionOptionsForType<TEntity>;
 
 export function isValueType(type: any): type is ValueConstructor {
 	return type === String || type === Number || type === Date || type === Boolean;

--- a/src/type.ts
+++ b/src/type.ts
@@ -623,7 +623,7 @@ export function Type$generateConstructor(type: Type, fullName: string, baseType:
 	// The final name to use is the last token
 	let finalName = token;
 
-	let BaseConstructor: EntityConstructor;
+	let BaseConstructor: EntityConstructor | typeof Entity;
 
 	if (baseType) {
 		BaseConstructor = baseType.jstype;

--- a/src/type.ts
+++ b/src/type.ts
@@ -40,7 +40,7 @@ export class Type {
 	readonly initExisting: EventSubscriber<Type, EntityInitExistingEventArgs>;
 	// readonly conditionsChanged: EventSubscriber<Type, ConditionTargetsChangedEventArgs>;
 
-	constructor(model: Model, fullName: string, baseType: Type = null, format: string | Format<Entity>, options?: TypeExtensionOptions<unknown>) {
+	constructor(model: Model, fullName: string, baseType: Type = null, format: string | Format<Entity>, options?: TypeExtensionOptionsForType<unknown>) {
 		this.model = model;
 		this.fullName = fullName;
 		this.jstype = Type$generateConstructor(this, fullName, baseType, model.settings.useGlobalObject ? getGlobalObject() : null);
@@ -391,7 +391,7 @@ export class Type {
 	 * Extends the current type with the specified format, properties and methods
 	 * @param options The options specifying how to extend the type
 	 */
-	extend(options: TypeExtensionOptions<unknown>): void {
+	extend(options: TypeExtensionOptionsForType<unknown>): void {
 		let type = this;
 
 		// Utility function to convert a path string into a resolved array of Property and PropertyChain instances
@@ -546,11 +546,11 @@ export interface RuleOrMethodOptions<EntityType> {
 
 export type RuleOrMethodFunctionOrOptions<EntityType> = ((this: EntityOfType<EntityType>, ...args: any[]) => any) | RuleOrMethodOptions<EntityType>;
 
-export type TypeExtensionOptions<EntityType> = {
+export type TypeExtensionOptionsForType<EntityType> = {
 	[P in keyof EntityType]: ValueConstructorForType<EntityType[P]> | string | PropertyOptions<EntityType, EntityType[P]> | RuleOrMethodFunctionOrOptions<EntityType>;
 }
 
-export type TypeOptions<EntityType> = TypeBasicOptions & TypeExtensionOptions<EntityType>;
+export type TypeOptionsForType<EntityType> = TypeBasicOptions & TypeExtensionOptionsForType<EntityType>;
 
 export function isValueType(type: any): type is ValueConstructor {
 	return type === String || type === Number || type === Date || type === Boolean;

--- a/src/type.ts
+++ b/src/type.ts
@@ -511,7 +511,7 @@ export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
 }
 
-export interface TypeOptions {
+interface TypeBasicOptions {
 	$extends?: string;
 	$format?: string | Format<Entity>;
 }
@@ -526,6 +526,8 @@ export type RuleOrMethodFunctionOrOptions<EntityType extends Entity> = ((this: E
 export interface TypeExtensionOptions<EntityType extends Entity> {
 	[name: string]: string | ValueType | PropertyOptions | RuleOrMethodFunctionOrOptions<EntityType>;
 }
+
+export type TypeOptions<EntityType> = TypeBasicOptions & TypeExtensionOptions<EntityType>;
 
 export function isValueType(type: any): type is ValueType {
 	return type === String || type === Number || type === Date || type === Boolean;

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,5 +1,5 @@
 import { Model } from "./model";
-import { Entity, EntityConstructorForType, EntityInitNewEventArgs, EntityInitExistingEventArgs, EntityRegisteredEventArgs, EntityConstructor, EntityOfType } from "./entity";
+import { Entity, EntityInitNewEventArgs, EntityInitExistingEventArgs, EntityRegisteredEventArgs, EntityConstructor, EntityOfType, EntityInitNewEventArgsForType, EntityInitExistingEventArgsForType, EntityConstructorForType } from "./entity";
 import { Property, PropertyOptions, Property$generateOwnProperty, Property$generatePrototypeProperty, Property$generateShortcuts } from "./property";
 import { navigateAttribute, getTypeName, parseFunctionName, ensureNamespace, getGlobalObject, entries } from "./helpers";
 import { Event, EventSubscriber } from "./events";
@@ -36,8 +36,8 @@ export class Type {
 
 	readonly _formats: { [name: string]: Format<any> };
 
-	readonly initNew: EventSubscriber<Type, EntityInitNewEventArgs<Entity>>;
-	readonly initExisting: EventSubscriber<Type, EntityInitExistingEventArgs<Entity>>;
+	readonly initNew: EventSubscriber<Type, EntityInitNewEventArgs>;
+	readonly initExisting: EventSubscriber<Type, EntityInitExistingEventArgs>;
 	// readonly conditionsChanged: EventSubscriber<Type, ConditionTargetsChangedEventArgs>;
 
 	constructor(model: Model, fullName: string, baseType: Type = null, format: string | Format<Entity>, options?: TypeExtensionOptions<Entity>) {
@@ -59,8 +59,8 @@ export class Type {
 			baseType.derivedTypes.push(this);
 		}
 
-		this.initNew = new Event<Type, EntityInitNewEventArgs<Entity>>();
-		this.initExisting = new Event<Type, EntityInitExistingEventArgs<Entity>>();
+		this.initNew = new Event<Type, EntityInitNewEventArgs>();
+		this.initExisting = new Event<Type, EntityInitExistingEventArgs>();
 		// this.conditionsChanged = new Event<Type, ConditionTargetsChangedEventArgs>();
 
 		// Set Format
@@ -173,7 +173,7 @@ export class Type {
 			}
 		}
 
-		(this.model.entityRegistered as Event<Model, EntityRegisteredEventArgs<Entity>>).publish(this.model, { entity: obj });
+		(this.model.entityRegistered as Event<Model, EntityRegisteredEventArgs>).publish(this.model, { entity: obj });
 	}
 
 	changeObjectId(oldId: string, newId: string): Entity | void {
@@ -504,7 +504,7 @@ export class Type {
 
 export type Value = string | number | Date | boolean;
 export type ValueType = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
-export type EntityType = EntityConstructorForType<Entity>;
+export type EntityType = EntityConstructor;
 export type PropertyType = ValueType | EntityType | ObjectConstructor;
 
 export interface TypeConstructor {
@@ -512,8 +512,8 @@ export interface TypeConstructor {
 }
 
 export interface TypeOfType<T> extends Type {
-	readonly initNew: EventSubscriber<TypeOfType<T>, EntityInitNewEventArgs<EntityOfType<T>>>;
-	readonly initExisting: EventSubscriber<TypeOfType<T>, EntityInitExistingEventArgs<EntityOfType<T>>>;
+	readonly initNew: EventSubscriber<TypeOfType<T>, EntityInitNewEventArgsForType<T>>;
+	readonly initExisting: EventSubscriber<TypeOfType<T>, EntityInitExistingEventArgsForType<T>>;
 	createIfNotExists(state: any): EntityOfType<T>;
 	createSync(state: any): EntityOfType<T>;
 	create(state: any): Promise<EntityOfType<T>>;
@@ -581,7 +581,7 @@ export function isValueArray(value: any): value is Value[] {
 	return isValueType(itemType);
 }
 
-export function isEntityType(type: any): type is EntityType {
+export function isEntityType(type: any): type is EntityConstructorForType<any> {
 	return type.meta && type.meta instanceof Type;
 }
 
@@ -600,7 +600,7 @@ export function Type$generateMethod(type: Type, target: any, name: string, fn: F
 // TODO: Get rid of disableConstruction?
 let disableConstruction = false;
 
-export function Type$generateConstructor(type: Type, fullName: string, baseType: Type = null, global: any = null): EntityConstructorForType<Entity> {
+export function Type$generateConstructor(type: Type, fullName: string, baseType: Type = null, global: any = null): EntityConstructor {
 	// Create namespaces as needed
 	let nameTokens: string[] = fullName.split(".");
 	let token: string = nameTokens.shift();

--- a/src/type.ts
+++ b/src/type.ts
@@ -391,7 +391,7 @@ export class Type {
 	 * Extends the current type with the specified format, properties and methods
 	 * @param options The options specifying how to extend the type
 	 */
-	extend(options: TypeExtensionOptions<any>): void {
+	extend(options: TypeExtensionOptions<unknown>): void {
 		let type = this;
 
 		// Utility function to convert a path string into a resolved array of Property and PropertyChain instances

--- a/src/type.ts
+++ b/src/type.ts
@@ -18,7 +18,7 @@ export class Type {
 	// changed without fundamentally changing what it represents
 	readonly model: Model;
 	readonly fullName: string;
-	readonly jstype: ReferenceType;
+	readonly jstype: EntityType;
 	readonly baseType: Type;
 	readonly derivedTypes: Type[];
 
@@ -504,8 +504,8 @@ export class Type {
 
 export type Value = string | number | Date | boolean;
 export type ValueType = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
-export type ReferenceType = EntityConstructorForType<Entity>;
-export type PropertyType = ValueType | ReferenceType | ObjectConstructor;
+export type EntityType = EntityConstructorForType<Entity>;
+export type PropertyType = ValueType | EntityType | ObjectConstructor;
 
 export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
@@ -576,7 +576,7 @@ export function isValueArray(value: any): value is Value[] {
 	return isValueType(itemType);
 }
 
-export function isEntityType(type: any): type is ReferenceType {
+export function isEntityType(type: any): type is EntityType {
 	return type.meta && type.meta instanceof Type;
 }
 

--- a/src/type.ts
+++ b/src/type.ts
@@ -18,7 +18,7 @@ export class Type {
 	// changed without fundamentally changing what it represents
 	readonly model: Model;
 	readonly fullName: string;
-	readonly jstype: EntityType;
+	readonly jstype: EntityConstructor;
 	readonly baseType: Type;
 	readonly derivedTypes: Type[];
 
@@ -504,14 +504,14 @@ export class Type {
 
 export type Value = string | number | Date | boolean;
 export type ValueType = StringConstructor | NumberConstructor | DateConstructor | BooleanConstructor;
-export type EntityType = EntityConstructor;
-export type PropertyType = ValueType | EntityType | ObjectConstructor;
+export type PropertyType = ValueType | EntityConstructor | ObjectConstructor;
 
 export interface TypeConstructor {
 	new(model: Model, fullName: string, baseType?: Type, origin?: string): Type;
 }
 
 export interface TypeOfType<T> extends Type {
+	readonly jstype: EntityConstructorForType<T>;
 	readonly initNew: EventSubscriber<TypeOfType<T>, EntityInitNewEventArgsForType<T>>;
 	readonly initExisting: EventSubscriber<TypeOfType<T>, EntityInitExistingEventArgsForType<T>>;
 	createIfNotExists(state: any): EntityOfType<T>;

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -215,7 +215,7 @@ describe("Type", () => {
 					Leaf: {
 						type: "Branch.Leaf"
 					}
-				}
+				} as any
 			});
 			const branch = await model.types.Branch.create({ Id: 1, Leaf: { LeafId: "1" } }) as any;
 			expect(branch.meta.type.fullName).toBe("Branch");

--- a/src/type.unit.ts
+++ b/src/type.unit.ts
@@ -1,3 +1,4 @@
+import { TEntityConstructor } from "./entity";
 import { Model } from "./model";
 
 describe("Type", () => {
@@ -144,32 +145,44 @@ describe("Type", () => {
 	});
 
 	describe("createIfNotExists", () => {
-		let model: Model;
+		type Namespace = {
+			Test: Test;
+		};
+
+		type Test = {
+			Id: string;
+			Name: string;
+			Sibling: Test;
+		};
+
+		let Types: { [T in keyof Namespace]: TEntityConstructor<Namespace[T]> } = {} as any;
+
 		beforeEach(() => {
-			model = new Model({
-				Entity: {
+			return new Model({
+				$namespace: Types as any,
+				Test: {
 					Id: { identifier: true, type: String },
 					Name: String,
-					Sibling: "Entity"
+					Sibling: "Test"
 				}
 			});
 		});
 
 		it("should create new instance if id is not known", () => {
-			const entity = model.types.Entity.createIfNotExists({ Id: "x", Name: "Test123" });
+			const entity = Types.Test.meta.createIfNotExists({ Id: "x", Name: "Test123" });
 			expect(entity.Id).toBe("x");
 			expect(entity.Name).toBe("Test123");
 		});
 
 		it("should create new instance if id is not provided", () => {
-			const entity = model.types.Entity.createIfNotExists({ Name: "Test123" });
+			const entity = Types.Test.meta.createIfNotExists({ Name: "Test123" });
 			expect(entity.Id).toBeNull();
 			expect(entity.Name).toBe("Test123");
 		});
 
 		it("should return known instance if id is known", () => {
-			const known = model.types.Entity.createSync({ Id: "x", Name: "Test123" });
-			expect(model.types.Entity.createIfNotExists({ Id: "x", Name: "New123" })).toBe(known);
+			const known = Types.Test.meta.createSync({ Id: "y", Name: "Test123" });
+			expect(Types.Test.meta.createIfNotExists({ Id: "y", Name: "New123" })).toBe(known);
 			expect(known.Name).toBe("Test123");
 		});
 	});

--- a/test/async-data-loader.ts
+++ b/test/async-data-loader.ts
@@ -46,10 +46,6 @@ export default function AsyncDataLoader(typeName: string, map: { [id: string]: a
 				.then(() => ids.map(id => loaded[id]))
 				.then(objs => isList ? objs : objs[0]);
 		}
-
-		// return null so the framework knows there is no async resolution for this value
-		else
-			return null;
 	}
 
 	return asyncDataLoader;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,12 +35,12 @@
 		"./src/**/*.ts"
 	],
 	"exclude": [
+		"node_modules",
 		"dist",
 		"build",
 		"out",
 		"lib",
 		"@types",
-		"node_modules",
 		"./src/**/*.unit.ts"
 	]
 }


### PR DESCRIPTION
**Summary**: model.js provides an entity type system, but does not effectively leverage TypeScript. This PR introduces a `createModel` function that enables creating a model that is type aware, and generic types that allow the model.js APIs to leverage the specific types of the model.

_Example_:
```
type Person = { Name: string };
type Namespace = { Person: Person };

// The createModel arguments are type checked based on the types in the namespace (i.e. Person)
const model = await createModel<Namespace>({
    Person: {
        Name: String,
        Initials: {
            get() {
                // "this" is EntityOfType<Person>
            }
        }
    }
});

// The model knows what types it contains
const personType = model.Person;

// The types included on the model are TS type-specific, and type check arguments and return specific types
const person = Person.meta.create({ Name: "Alice" });

// The resulting entity is `EntityOfType<Person>`
console.log(person.Name);
```