### PR TITLE
Use defineProperty for entity and object meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 ### Changed
-- Use `Object.defineProperty` for fields `Entity` and `ObjectMeta`.
+- Use `Object.defineProperty` for fields of `Entity` and `ObjectMeta`.
 ## [0.8.44] - 2023-06-12
 ### Fixed
 - Ignore undefined or invalid value for reference property in initial entity state

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## [Unreleased]
+### Changed
+- Use `Object.defineProperty` for fields `Entity` and `ObjectMeta`.
 ## [0.8.44] - 2023-06-12
 ### Fixed
 - Ignore undefined or invalid value for reference property in initial entity state

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,13 @@ module.exports = {
 	// globalTeardown: "<rootDir>/testing/unit/global-teardown",
 	// setupFilesAfterEnv: ["<rootDir>/testing/unit/setup"],
 	testMatch: ["**/(*.)unit.[jt]s"],
-	testPathIgnorePatterns: ["/node_modules/", "/dist/"],
+	testPathIgnorePatterns: [
+		"<rootDir>/node_modules/",
+		"<rootDir>/out/",
+		"<rootDir>/lib/",
+		"<rootDir>/esm/",
+		"<rootDir>/@types/"
+	],
 	moduleFileExtensions: ["js", "ts", "json"],
 	transform: {
 		"^.+\\.[jt]s$": "babel-jest",

--- a/src/entity.ts
+++ b/src/entity.ts
@@ -17,7 +17,7 @@ export class Entity {
 
 	readonly accessed: EventSubscriber<Entity, EntityAccessEventArgs>;
 	readonly changed: EventSubscriber<Entity, EntityChangeEventArgs>;
-	private _context: InitializationContext = null;
+	private _context: InitializationContext;
 	readonly initialized: Promise<void>;
 
 	constructor(); // Prototype assignment *** used internally
@@ -30,8 +30,9 @@ export class Entity {
 		else if (Entity.ctorDepth === 0)
 			throw new Error("Entity constructor should not be called directly.");
 		else {
-			this.accessed = new Event<Entity, EntityAccessEventArgs>();
-			this.changed = new Event<Entity, EntityChangeEventArgs>();
+			Object.defineProperty(this, "_context", { enumerable: false, configurable: false, writable: true, value: null });
+			Object.defineProperty(this, "accessed", { enumerable: false, configurable: false, writable: false, value: new Event<Entity, EntityAccessEventArgs>() });
+			Object.defineProperty(this, "changed", { enumerable: false, configurable: false, writable: false, value: new Event<Entity, EntityChangeEventArgs>() });
 
 			let isNew = false;
 
@@ -50,7 +51,7 @@ export class Entity {
 			if (!(context instanceof InitializationContext))
 				context = new InitializationContext(isNew);
 
-			this.meta = new ObjectMeta(type, this, id, isNew);
+			Object.defineProperty(this, "meta", { enumerable: true, configurable: false, writable: false, value: new ObjectMeta(type, this, id, isNew) });
 
 			Object.defineProperty(this, "__fields__", { enumerable: false, configurable: false, writable: false, value: {} });
 			Object.defineProperty(this, "__pendingInit__", { enumerable: false, configurable: false, writable: false, value: {} });

--- a/src/object-meta.ts
+++ b/src/object-meta.ts
@@ -10,7 +10,7 @@ export class ObjectMeta {
 	readonly type: Type;
 	readonly entity: Entity;
 
-	readonly __pendingInvocation__: Rule[] = [];
+	readonly __pendingInvocation__: Rule[];
 
 	id: string;
 	isNew: boolean;

--- a/src/object-meta.ts
+++ b/src/object-meta.ts
@@ -18,11 +18,12 @@ export class ObjectMeta {
 	conditions: ObservableArray<ConditionTarget>;
 
 	constructor(type: Type, entity: Entity, id: string, isNew: boolean) {
-		this.type = type;
-		this.entity = entity;
-		this.id = id;
-		this.isNew = isNew;
-		this.conditions = ObservableArray.create<ConditionTarget>();
+		Object.defineProperty(this, "type", { enumerable: true, configurable: false, writable: false, value: type });
+		Object.defineProperty(this, "entity", { enumerable: true, configurable: false, writable: false, value: entity });
+		Object.defineProperty(this, "id", { enumerable: true, configurable: false, writable: true, value: id });
+		Object.defineProperty(this, "isNew", { enumerable: true, configurable: false, writable: true, value: isNew });
+		Object.defineProperty(this, "conditions", { enumerable: true, configurable: false, writable: true, value: ObservableArray.create<ConditionTarget>() });
+		Object.defineProperty(this, "__pendingInvocation__", { enumerable: false, configurable: false, writable: false, value: [] });
 	}
 
 	/**


### PR DESCRIPTION
For  `Entity` and `ObjectMeta`, use `Object.defineProperty` so that private and read-only fields are not enumerable or configurable.

NOTE: `configurable: false` is needed to prevent Vue from making `Entity`'s properties reactive when they shouldn't be.